### PR TITLE
Mods for archives

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run application",
+			"type": "node",
+			"request": "launch",
+			"runtimeExecutable": "/home/cjativa/.nvm/versions/node/v16.17.0/bin/node",
+			"program": "${workspaceFolder}/dist/app.js",
+			"restart": true,
+			"console": "internalConsole",
+			"internalConsoleOptions": "neverOpen",
+			"outFiles": [
+				"${workspaceFolder}/dist/**/*.js"
+			],
+		},
+	]
+}

--- a/scripts/createUsers.sql
+++ b/scripts/createUsers.sql
@@ -1,0 +1,6 @@
+-- Create the netx_dams user
+CREATE ROLE netx_dams NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT LOGIN NOREPLICATION NOBYPASSRLS PASSWORD 'netx_dams';
+GRANT REFERENCES, SELECT ON TABLE public.constituent_records TO netx_dams;
+GRANT REFERENCES, SELECT ON TABLE public.main_object_information TO netx_dams;
+GRANT REFERENCES, SELECT ON TABLE public.media_information TO netx_dams;
+GRANT REFERENCES, SELECT ON TABLE public.object_constituent_mappings TO netx_dams;

--- a/src/classes/mainSyncProcess.ts
+++ b/src/classes/mainSyncProcess.ts
@@ -17,10 +17,13 @@ export class MainSyncProcess {
 	private async getCollectionObjectIDs(): Promise<CollectionObjectIDs> {
 
 		// Query to get count of objects we'll end up working with - 67 is the type for the text type
+		// We want to avoid pulling non-existent text entry values 
 		const objectIdQuery = `
 			SELECT ID 
 			FROM TextEntries 
-			WHERE TextTypeId = 67`;
+			WHERE TextTypeId = 67
+			AND TextEntry IS NOT NULL
+			AND TextEntry != ''`;
 
 		// From knowledge of the database - we have around 7622 objects we will work with - get the exact count to make sure
 		const recordset = (await this.tmsCon.executeQuery(objectIdQuery)).recordset as ObjectID[];
@@ -54,7 +57,7 @@ export class MainSyncProcess {
 		const { recordset, count } = await this.getCollectionObjectIDs();
 
 		// Set up batches of object retrieval to run
-		const parallelExecutionLimit = 100;
+		const parallelExecutionLimit = 75;
 		const numberOfBatches = Math.ceil(count / parallelExecutionLimit);
 
 		console.log(`There will be ${numberOfBatches} batches of ${parallelExecutionLimit} executions each`);

--- a/src/classes/objectProcess.ts
+++ b/src/classes/objectProcess.ts
@@ -82,13 +82,11 @@ export class ObjectProcess {
 			resolve('');
 
 			// Inform that the batch this process belongs to has completed
-			if (this.processNumber > 0 && this.processNumber % 99 === 0) {
-				console.log(`Completed Batch Number ${this.batchNumber}`);
-			}
+			console.log(`Completed Batch Number ${this.batchNumber} Process Number ${this.processNumber}`);
 		});
 	}
 
-	/** Performs the necessary functions in order to prepate and add an object to NetX database */
+	/** Performs the necessary functions in order to prepate and add an object to NetX database */ 
 	private async addObjectRecordToNetX(or: ObjectRecord) {
 
 		const {

--- a/src/classes/objectProcess.ts
+++ b/src/classes/objectProcess.ts
@@ -44,7 +44,8 @@ export class ObjectProcess {
 			SELECT TextEntry 
 			FROM TextEntries 
 			WHERE ID = ${this.objectId} 
-			AND TextTypeId = 67`;
+			AND TextTypeId = 67
+			AND TextEntry IS NOT NULL`;
 
 			// Execute the query to get the text entry
 			const queryResult = await this.tmsCon.executeQuery(collectionPayloadQuery);

--- a/src/classes/objectProcess.ts
+++ b/src/classes/objectProcess.ts
@@ -3,7 +3,7 @@ import { SQLConnection } from './sql';
 import { NetXTables } from '../constants/netXDatabase';
 import { PoolClient } from 'pg';
 import QueryHelpers from '../constants/queryHelpers';
-import ObjectHelpers from '../constants/objectHelpers';
+import ObjectHelpers, { ARCHIVE_TYPE, MEDIA_TYPE } from '../constants/objectHelpers';
 import { OBJECT_RECORD } from '../constants/names';
 
 const NEWLINE_RETURN_TAB_REGEX = /[\n\r\t]/g;
@@ -122,8 +122,9 @@ export class ObjectProcess {
 		}
 
 		// Add media information record only if the `renditionNumber` exists for the object
-		// which will not be true for archive type objects, as they have no rendition number nor media data
-		if (mediaInformationObject.hasOwnProperty(`renditionNumber`)) {
+		// and the object type is `media`, as both object types will now have rendition numbers
+		// but only media types have actual valid media information
+		if (mainInformationObject.objectType === MEDIA_TYPE && mediaInformationObject.renditionNumber) {
 			const {
 				query: miQuery,
 				values: miValues,

--- a/src/classes/objectProcess.ts
+++ b/src/classes/objectProcess.ts
@@ -122,9 +122,9 @@ export class ObjectProcess {
 		}
 
 		// Add media information record only if the `renditionNumber` exists for the object
-		// and the object type is `media`, as both object types will now have rendition numbers
-		// but only media types have actual valid media information
-		if (mainInformationObject.objectType === MEDIA_TYPE && mediaInformationObject.renditionNumber) {
+		// as both object types `archive` and `media` will now have rendition numbers
+		// but only `media` records will have a full-set of media information
+		if (mediaInformationObject.renditionNumber) {
 			const {
 				query: miQuery,
 				values: miValues,

--- a/src/classes/sql.ts
+++ b/src/classes/sql.ts
@@ -37,7 +37,7 @@ export class SQLConnection {
 
 		try {
 			// Set connection to mssql
-			if (this.type == MSSQL) {
+			if (this.type === MSSQL) {
 				this.connection = await mssql.connect({
 					user: this.user,
 					password: this.password,

--- a/src/classes/sql.ts
+++ b/src/classes/sql.ts
@@ -94,7 +94,8 @@ export class SQLConnection {
 		}
 
 		catch (error) {
-			console.log(`An error occurred running the provided query on the ${this.type} database`, error);
+			console.log(`An error occurred running the provided query on the ${this.type} database`, query);
+			console.log(error);
 		}
 	}
 

--- a/src/constants/netXDatabase.ts
+++ b/src/constants/netXDatabase.ts
@@ -39,7 +39,9 @@ export const NetXTables: TablesInformation = {
 			{ name: 'bibliography', type: 'VARCHAR' },
 			{ name: 'dimensions', type: 'VARCHAR' },
 			{ name: 'caption', type: 'VARCHAR' },
-			{ name: 'ImagecreditLine', type: 'VARCHAR', }
+			{ name: 'ImagecreditLine', type: 'VARCHAR', },
+			{ name: 'objectType', type: 'VARCHAR' },
+			{ name: 'description', type: 'VARCHAR' }
 		]
 	},
 

--- a/src/constants/objectHelpers.ts
+++ b/src/constants/objectHelpers.ts
@@ -16,10 +16,10 @@ const createObjectsForTables = (or: ObjectRecord): ObjectsForTables => {
 	let { mainInformationObject, constituentRecordsList, mediaInformationObject } = parseRecordToObjects(or);
 
 	// Now that we've created each needed object -- the objects require some calculated fields
-	mainInformationObject['caption'] = FieldHelpers.generateCaptionForMainObject(mainInformationObject, constituentRecordsList);
-
-	// Add the calculated fields for constituent records
-	constituentRecordsList = FieldHelpers.generateConstituentCalculatedFields(constituentRecordsList);
+	if (constituentRecordsList) {
+		mainInformationObject['caption'] = FieldHelpers.generateCaptionForMainObject(mainInformationObject, constituentRecordsList);
+		constituentRecordsList = FieldHelpers.generateConstituentCalculatedFields(constituentRecordsList);
+	}
 
 	return { mainInformationObject, constituentRecordsList, mediaInformationObject };
 };
@@ -56,11 +56,19 @@ const parseRecordToObjects = (or: ObjectRecord): ObjectsForTables => {
 		if (fieldName === CONSTITUENT_RECORD) {
 			constituentRecordsList = createListOfConstituentRecordObjects(or.ConstituentRecord)
 		}
+
+		// Existince of the `renditionNumber` field in the `mediaInformationObject` will determine
+		// for us if this is a normal media object, or an archive, which has no media
+		if (mediaInformationObject.hasOwnProperty('renditionNumber')) {
+			mainInformationObject['objectType'] = 'media';
+		} else {
+			mainInformationObject['objectType'] = 'archive';
+		}
 	}
 
 	return {
 		mainInformationObject,
-		constituentRecordsList, 
+		constituentRecordsList,
 		mediaInformationObject,
 	};
 };

--- a/src/constants/objectHelpers.ts
+++ b/src/constants/objectHelpers.ts
@@ -64,10 +64,10 @@ const parseRecordToObjects = (or: ObjectRecord): ObjectsForTables => {
 	}
 
 	// We need to store the determined object type for this record and
-	// if it's an `archive` type, we'll give it a simulated rendition number
+	// if it's an `archive` type, we'll give it a simulated rendition number using the object number
 	mainInformationObject['objectType'] = determinedObjectType;
 	if (determinedObjectType === ARCHIVE_TYPE) {
-		mediaInformationObject['renditionNumber'] = mainInformationObject['objectId']
+		mediaInformationObject['renditionNumber'] = mainInformationObject['objectNumber']
 	}
 
 	return {

--- a/src/constants/objectHelpers.ts
+++ b/src/constants/objectHelpers.ts
@@ -38,7 +38,7 @@ const parseRecordToObjects = (or: ObjectRecord): ObjectsForTables => {
 	const mediaInformationObject = {};
 	let constituentRecordsList: ObjectRecord['ConstituentRecord'];
 
-	// Existence of the `renditionNumber` in the object record determined if this is a media or archive type
+	// Existence of the `renditionNumber` in the object record determines if this is a media or archive type
 	const determinedObjectType = or.hasOwnProperty('renditionNumber') ? MEDIA_TYPE : ARCHIVE_TYPE;
 
 	// Get the field names and values -- i.e. the eventual column names, and values for this object
@@ -67,7 +67,7 @@ const parseRecordToObjects = (or: ObjectRecord): ObjectsForTables => {
 	// if it's an `archive` type, we'll give it a simulated rendition number using the object number
 	mainInformationObject['objectType'] = determinedObjectType;
 	if (determinedObjectType === ARCHIVE_TYPE) {
-		mediaInformationObject['renditionNumber'] = mainInformationObject['objectNumber']
+		mediaInformationObject['renditionNumber'] = formatPSV(mainInformationObject['objectNumber'])
 	}
 
 	return {
@@ -97,6 +97,12 @@ const createListOfConstituentRecordObjects = (constituentRecords: ObjectRecord['
 		return constituentRecordObject;
 	});
 };
+
+/** Formats a period-separated value by replacing those periods with dashes */
+const formatPSV = (value: string) => {
+	const formatted = value.replace(/\./g,'-')
+	return formatted;
+}
 
 const ObjectHelpers = {
 	createObjectsForTables

--- a/src/constants/objectHelpers.ts
+++ b/src/constants/objectHelpers.ts
@@ -58,7 +58,11 @@ const parseRecordToObjects = (or: ObjectRecord): ObjectsForTables => {
 		}
 	}
 
-	return { mainInformationObject, constituentRecordsList, mediaInformationObject };
+	return {
+		mainInformationObject,
+		constituentRecordsList, 
+		mediaInformationObject,
+	};
 };
 
 /** Takes the list of constituent records and transforms them by trimming out any unneeded fields that were included in the object */

--- a/storedProcedures/SP_BF_OnlineCollectionPayload.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayload.sql
@@ -1,163 +1,290 @@
 USE [TMS]
 GO
-/****** Object:  StoredProcedure [dbo].[SP_BF_OnlineCollectionPayload]    Script Date: 12/19/2022 9:00:56 PM ******/
-SET ANSI_NULLS ON
+	/****** Object:  StoredProcedure [dbo].[SP_BF_OnlineCollectionPayload]    Script Date: 12/19/2022 9:00:56 PM ******/
+SET
+	ANSI_NULLS ON
 GO
-SET QUOTED_IDENTIFIER ON
+SET
+	QUOTED_IDENTIFIER ON
 GO
+	-- =============================================
+	-- Author:		<Author,,Name>
+	-- Create date: <Create Date,,>
+	-- Description:	<Description,,>
+	-- =============================================
+	ALTER PROCEDURE [dbo].[SP_BF_OnlineCollectionPayload] -- Add the parameters for the stored procedure here
+	@ObjectID nvarchar(max) AS BEGIN create table #tempImage(ObjectID int, ObjectNumber nvarchar(64), Title nvarchar(450), Classification nvarchar(64),
+	OnView smallint,
+	BeginDate int,
+	EndDate int,
+	Dated nvarchar(255),
+	Period nvarchar(120),
+	Culture nvarchar(120),
+	Medium nvarchar(max),
+	Dimensions nvarchar(max),
+	ImageCreditLine nvarchar(max),
+	Marks nvarchar(max),
+	Inscriptions nvarchar(max),
+	ExhibitionHistory nvarchar(max),
+	Bibliography nvarchar(max),
+	CopyrightStatus nvarchar(48),
+	CopyrightsTypeID int,
+	CreditLine nvarchar(max),
+	copyright nvarchar(max),
+	ShortDescription nvarchar(max),
+	LongDescription nvarchar(max),
+	VisualDescription nvarchar(max),
+	PublishedProvenance nvarchar(max),
+	EnsembleIndex nvarchar(max),
+	PrimaryImageAltText nvarchar(max),
+	AudioTour nvarchar(max),
+	Site nvarchar(128),
+	Room nvarchar(128),
+	Wall nvarchar(64),
+	HomeLocation nvarchar(512),
+	MediaFile nvarchar(450),
+	MediaView nvarchar(64),
+	MediaDescription nvarchar(max),
+	PublicAccess smallint,
+	ISPrimary smallint,
+	PhotographerName nvarchar(450),
+	MediaRole nvarchar(32),
+	PublicCaption nvarchar(max),
+	RenditionDate nvarchar(19),
+	Technique nvarchar(255),
+	RenditionNumber nvarchar(64)
+) -- SET NOCOUNT ON added to prevent extra result sets from
+-- interfering with SELECT statements.
+SET
+	NOCOUNT ON;
 
-
-
-
--- =============================================
--- Author:		<Author,,Name>
--- Create date: <Create Date,,>
--- Description:	<Description,,>
--- =============================================
-ALTER PROCEDURE [dbo].[SP_BF_OnlineCollectionPayload] 
-	-- Add the parameters for the stored procedure here
-	   @ObjectID nvarchar(max) 
-AS
-BEGIN
-
-create table #tempImage(ObjectID int, ObjectNumber nvarchar(64), Title nvarchar(450), Classification nvarchar(64),
- OnView smallint, BeginDate int, EndDate int, Dated nvarchar(255), Period nvarchar(120), Culture nvarchar(120), 
- Medium nvarchar(max), Dimensions nvarchar(max) , ImageCreditLine nvarchar(max), Marks nvarchar(max), Inscriptions nvarchar(max), 
- ExhibitionHistory nvarchar(max), Bibliography nvarchar(max), CopyrightStatus nvarchar(48), CopyrightsTypeID int,
- CreditLine nvarchar(max), copyright nvarchar(max), ShortDescription nvarchar(max), 
- LongDescription nvarchar(max), VisualDescription nvarchar(max), PublishedProvenance nvarchar(max), 
- EnsembleIndex nvarchar(max), PrimaryImageAltText nvarchar(max), AudioTour nvarchar(max), Site nvarchar(128), 
- Room nvarchar(128), Wall nvarchar(64), HomeLocation nvarchar(512), MediaFile nvarchar(450), MediaView nvarchar(64),
- MediaDescription nvarchar(max), PublicAccess smallint, ISPrimary smallint, PhotographerName nvarchar(450),MediaRole nvarchar(32), 
- PublicCaption nvarchar(max),RenditionDate nvarchar(19), Technique nvarchar(255), RenditionNumber nvarchar(64) ) 
-	-- SET NOCOUNT ON added to prevent extra result sets from
-	-- interfering with SELECT statements.
-	SET NOCOUNT ON;
-    -- Insert statements for procedure here
-	insert into #tempImage	SELECT distinct
-	O.ObjectID, O.ObjectNumber, O.Title, Cs.Classification, O.OnView, O.DateBegin, O.DateEnd, O.Dated, Oc.Period, Oc.Culture, 
-	O.Medium, O.Dimensions, O.creditLine, O.Markings, O.Inscribed, 
-	case  when O.Exhibitions IS NOT NULL
-	        then '<p>' + REPLACE(O.Exhibitions,char(13)+char(10)+char(13)+char(10),'</p><p>') + '</p>'
-	        else O.Exhibitions end as Exhibitions,
-	case  when O.bibliography IS NOT NULL
-	        then '<p>' + REPLACE(O.bibliography,char(13)+char(10)+char(13)+char(10),'</p><p>') + '</p>'
-	        else O.bibliography end as bibliography, 
-	ort.ObjRightsType, obr.ObjRightsTypeID , obr.CreditLineRepro, obr.Copyright,
-	tes.TextEntryHTML, tel.TextEntryHTML, tev.TextEntryHTML, tep.TextEntryHTML, teei.TextEntryHTML, tepiat.TextEntryHTML, 
-	teat.TextEntryHTML, l.site, l.Room, l.UnitType, l.LocationString, mf.FileName , mm.MediaView, mm.Description, mm.PublicAccess,
-	x.PrimaryDisplay, conxref1.DisplayName, conxref1.Role, mm.PublicCaption, mr.RenditionDate, mr.Technique, mr.RenditionNumber
-	from Objects O 
+-- Insert statements for procedure here
+insert into
+	#tempImage	SELECT distinct
+	O.ObjectID,
+	O.ObjectNumber,
+	O.Title,
+	Cs.Classification,
+	O.OnView,
+	O.DateBegin,
+	O.DateEnd,
+	O.Dated,
+	Oc.Period,
+	Oc.Culture,
+	O.Medium,
+	O.Dimensions,
+	O.creditLine,
+	O.Markings,
+	O.Inscribed,
+	case
+		when O.Exhibitions IS NOT NULL then '<p>' + REPLACE(
+			O.Exhibitions,
+			char(13) + char(10) + char(13) + char(10),
+			'</p><p>'
+		) + '</p>'
+		else O.Exhibitions
+	end as Exhibitions,
+	case
+		when O.bibliography IS NOT NULL then '<p>' + REPLACE(
+			O.bibliography,
+			char(13) + char(10) + char(13) + char(10),
+			'</p><p>'
+		) + '</p>'
+		else O.bibliography
+	end as bibliography,
+	ort.ObjRightsType,
+	obr.ObjRightsTypeID,
+	obr.CreditLineRepro,
+	obr.Copyright,
+	tes.TextEntryHTML,
+	tel.TextEntryHTML,
+	tev.TextEntryHTML,
+	tep.TextEntryHTML,
+	teei.TextEntryHTML,
+	tepiat.TextEntryHTML,
+	teat.TextEntryHTML,
+	l.site,
+	l.Room,
+	l.UnitType,
+	l.LocationString,
+	mf.FileName,
+	mm.MediaView,
+	mm.Description,
+	mm.PublicAccess,
+	x.PrimaryDisplay,
+	conxref1.DisplayName,
+	conxref1.Role,
+	mm.PublicCaption,
+	mr.RenditionDate,
+	mr.Technique,
+	mr.RenditionNumber
+from
+	Objects O
 	/* Classification */
 	INNER JOIN ClassificationXRefs CXR ON O.ObjectID = CXR.Id
-    INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId
+	INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId
 	/* Period, Culture */
 	INNER JOIN ObjContext Oc ON Oc.ObjectID = O.ObjectID
 	/* CopyrightStatus, coyrightsstatusid, CreditLineReproduction and copyright */
 	INNER JOIN ObjRights obr ON obr.OBJECTID = O.ObjectID
 	INNER JOIN ObjRightsTypes Ort on Ort.ObjRightsTypeID = Obr.ObjRightsTypeID
 	/*text Entries - short description, long description, visual description, published provenance,
-	EnsembleIndex, PrimaryImageAltTxt and AudioTour */
-	LEFT OUTER JOIN TextEntries tes on tes.id = O.ObjectID and tes.Texttypeid = 48
-	LEFT OUTER JOIN TextEntries tel on tel.id = O.ObjectID and tel.Texttypeid = 49
-	LEFT OUTER JOIN TextEntries tev on tev.id = O.ObjectID and tev.Texttypeid = 50
-	LEFT OUTER JOIN TextEntries tep on tep.id = O.ObjectID and tep.Texttypeid = 55 
-	LEFT OUTER JOIN TextEntries teei on teei.id = O.ObjectID and teei.Texttypeid = 57 
-	LEFT OUTER JOIN TextEntries tepiat on tepiat.id = O.ObjectID and tepiat.Texttypeid = 54 
-	LEFT OUTER JOIN TextEntries teat on teat.id = O.ObjectID and teat.Texttypeid = 32 
+	 EnsembleIndex, PrimaryImageAltTxt and AudioTour */
+	LEFT OUTER JOIN TextEntries tes on tes.id = O.ObjectID
+	and tes.Texttypeid = 48
+	LEFT OUTER JOIN TextEntries tel on tel.id = O.ObjectID
+	and tel.Texttypeid = 49
+	LEFT OUTER JOIN TextEntries tev on tev.id = O.ObjectID
+	and tev.Texttypeid = 50
+	LEFT OUTER JOIN TextEntries tep on tep.id = O.ObjectID
+	and tep.Texttypeid = 55
+	LEFT OUTER JOIN TextEntries teei on teei.id = O.ObjectID
+	and teei.Texttypeid = 57
+	LEFT OUTER JOIN TextEntries tepiat on tepiat.id = O.ObjectID
+	and tepiat.Texttypeid = 54
+	LEFT OUTER JOIN TextEntries teat on teat.id = O.ObjectID
+	and teat.Texttypeid = 32
 	/* site, room, wall, homelocation */
-	INNER JOIN objcomponents obc on o.objectID = obc.ObjectID 	 
-    INNER JOIN locations l on obc.HomeLocationID  = l.LocationID
-	
-	 join 
-	 (select mx.TableID, mx.MediaMasterID, conds.ID, mx.PrimaryDisplay from condLineItems cli 
-	 join conditions conds on (conds.ConditionID = cli.ConditionID)
-	 join mediaxrefs mx on (mx.id = cli.CondLineItemID and mx.tableID = 97)
-	 union 
-	 (select mx.TableID, mx.MediaMasterID, o.objectID, mx.PrimaryDisplay from mediaxrefs mx  join Objects o on (mx.id = o.ObjectID and mx.tableID = 108) ))x
-  on x.ID = o.ObjectID
-
-	/* Photographer */	
-INNER JOIN MediaMaster mm On x.MediaMasterID = mm.MediaMasterID 
-INNER JOIN MediaRenditions mr ON (mm.MediaMasterID = mr.MediaMasterID and mm.PrimaryRendID = mr.RenditionID )
-left join MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
-join (select const.DisplayName,r.Role, cx.ID,cx.RoleTypeID,cx.RoleID  from ConXrefs cx join Roles r on (r.RoleID = cx.RoleID)
-                
-				join (select cts.DisplayName, cxd.ConXrefID, cxd.UnMasked  from ConAltNames cn
-                join Constituents cts on (cn.ConstituentID = cts.ConstituentID /*and cts.Active = 1*/)
-        join ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId))const
-
-        ON (cx.ConXrefID = const.ConXrefID and const.UnMasked = 1))conxref1
-        ON (mr.RenditionID = conxref1.ID and conxref1.RoleTypeID = 11 and conxref1.RoleID = 11) 
-
-		WHERE O.ObjectID = @ObjectID 
-	
-	
-
-	
-	/*INNER JOIN MediaXRefs mx On mx.ID = o.ObjectID And mx.TableID = 108 /*and Mx.PrimaryDisplay = 1*/
-	/* Photographer */	
-    INNER JOIN MediaMaster mm On Mx.MediaMasterID = mm.MediaMasterID 
-INNER JOIN MediaRenditions mr ON mm.MediaMasterID = mr.MediaMasterID
-INNER JOIN ConXrefs cx ON  mr.RenditionID = cx.ID and cx.RoleTypeID = 11 and cx.RoleID = 11
-INNER JOIN MediaFiles mf ON mr.PrimaryFileID = mf.FileID
-INNER JOIN Roles r on r.RoleID = cx.RoleID
-INNER JOIN ConXrefDetails cxd ON cx.ConXrefID = cxd.ConXrefID and cxd.UnMasked = 1
-INNER JOIN ConAltNames cn ON cxd.NameID = cn.AltNameId
-INNER JOIN Constituents cts ON cn.ConstituentID = cts.ConstituentID and cts.Active = 1 
-	 WHERE O.ObjectID = @ObjectID */
+	INNER JOIN objcomponents obc on o.objectID = obc.ObjectID
+	INNER JOIN locations l on obc.HomeLocationID = l.LocationID
+	join (
+		select
+			mx.TableID,
+			mx.MediaMasterID,
+			conds.ID,
+			mx.PrimaryDisplay
+		from
+			condLineItems cli
+			join conditions conds on (conds.ConditionID = cli.ConditionID)
+			join mediaxrefs mx on (
+				mx.id = cli.CondLineItemID
+				and mx.tableID = 97
+			)
+		union
+		(
+			select
+				mx.TableID,
+				mx.MediaMasterID,
+				o.objectID,
+				mx.PrimaryDisplay
+			from
+				mediaxrefs mx
+				join Objects o on (
+					mx.id = o.ObjectID
+					and mx.tableID = 108
+				)
+		)
+	) x on x.ID = o.ObjectID
+	/* Photographer */
+	INNER JOIN MediaMaster mm On x.MediaMasterID = mm.MediaMasterID
+	INNER JOIN MediaRenditions mr ON (
+		mm.MediaMasterID = mr.MediaMasterID
+		and mm.PrimaryRendID = mr.RenditionID
+	)
+	left join MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
+	join (
+		select
+			const.DisplayName,
+			r.Role,
+			cx.ID,
+			cx.RoleTypeID,
+			cx.RoleID
+		from
+			ConXrefs cx
+			join Roles r on (r.RoleID = cx.RoleID)
+			join (
+				select
+					cts.DisplayName,
+					cxd.ConXrefID,
+					cxd.UnMasked
+				from
+					ConAltNames cn
+					join Constituents cts on (
+						cn.ConstituentID = cts.ConstituentID
+						/*and cts.Active = 1*/
+					)
+					join ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId)
+			) const ON (
+				cx.ConXrefID = const.ConXrefID
+				and const.UnMasked = 1
+			)
+	) conxref1 ON (
+		mr.RenditionID = conxref1.ID
+		and conxref1.RoleTypeID = 11
+		and conxref1.RoleID = 11
+	)
+WHERE
+	O.ObjectID = @ObjectID
+	/** INNER JOIN MediaXRefs mx On mx.ID = o.ObjectID And mx.TableID = 108 and Mx.PrimaryDisplay = 1
+	 INNER JOIN MediaMaster mm On Mx.MediaMasterID = mm.MediaMasterID
+	 INNER JOIN MediaRenditions mr ON mm.MediaMasterID = mr.MediaMasterID
+	 INNER JOIN ConXrefs cx ON mr.RenditionID = cx.ID
+	 and cx.RoleTypeID = 11
+	 and cx.RoleID = 11
+	 INNER JOIN MediaFiles mf ON mr.PrimaryFileID = mf.FileID
+	 INNER JOIN Roles r on r.RoleID = cx.RoleID
+	 INNER JOIN ConXrefDetails cxd ON cx.ConXrefID = cxd.ConXrefID
+	 and cxd.UnMasked = 1
+	 INNER JOIN ConAltNames cn ON cxd.NameID = cn.AltNameId
+	 INNER JOIN Constituents cts ON cn.ConstituentID = cts.ConstituentID
+	 and cts.Active = 1
+	 WHERE
+	 O.ObjectID = @ObjectID * /
 	 /* Select * from #tempImage */
-
-	DECLARE	@return_value nvarchar(max)
-
-  Set @return_value = (SELECT  '{' + '"objectRecord":' + '[' + STUFF((
-    SELECT
+	DECLARE @return_value nvarchar(max)
+SET
+	@return_value = (
+		SELECT
+			'{' + '"objectRecord":' + '[' + STUFF(
+				(
+					SELECT
+						+ ',' + '{' + '"objectId":"' + CAST(ObjectID AS nvarchar(max)) + '",' + COALESCE('"objectNumber":"' + ObjectNumber + '",', '') + COALESCE(
+							'"title":"' + dbo.fn_String_Escape(
+								replace(
+									replace(
+										Title,
+										'\' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+        + COALESCE('" classification ":" '+ Classification + ' ",','')
+		+ COALESCE('" onView ":" '+ CAST(OnView AS nvarchar(max)) + ' ",','')
+        + COALESCE('" beginDate ":" '+ CAST(BeginDate AS nvarchar(max)) + ' ",','')
+		+ COALESCE('" endDate ":" '+ CAST(EndDate AS nvarchar(max)) + ' ",','')
+		+ COALESCE('" dated ":" ' + Dated + ' ",','')
+		+ COALESCE('" period ":" ' + Period + ' ",','')
+		+ COALESCE('" culture ":" ' + Culture + ' ",','')
+		+ COALESCE('" medium ":" ' + Medium + ' ",','')
+		+ COALESCE('" dimensions ":" ' + dbo.fn_String_Escape(replace(replace(Dimensions, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" ImagecreditLine ":" ' + dbo.fn_String_Escape(replace(replace(ImageCreditLine, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" copyrightStatus ":" ' + CopyrightStatus + ' ",','')
+		+ COALESCE('" copyrightsTypeID ":" ' + CAST(CopyrightsTypeID AS nvarchar(max)) + ' ",','')
+		+ COALESCE('" creditLine ":" ' + dbo.fn_String_Escape(replace(replace(CreditLine, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" copyright ":" ' + dbo.fn_String_Escape(replace(replace(Copyright, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 
+		+ COALESCE('" site ":" ' + Site + ' ",','')
+		+ COALESCE('" room ":" ' + Room + ' ",','')
+		+ COALESCE('" wall ":" ' + Wall + ' ",','')
+		+ COALESCE('" homeLocation ":" ' + HomeLocation + ' ",','')
+		+ COALESCE('" marks ":" ' + dbo.fn_String_Escape(replace(replace(Marks, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" inscriptions ":" ' + dbo.fn_String_Escape(replace(replace(Inscriptions, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" exhibitionHistory ":" ' + dbo.fn_String_Escape(replace(replace(ExhibitionHistory, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" bibliography ":" ' + dbo.fn_String_Escape(replace(replace(Bibliography, ' \ ' , ' \ \ '),CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 		
+		+ COALESCE('" shortDescription ":" ' + dbo.fn_String_Escape(replace(replace(ShortDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" longDescription ":" ' + dbo.fn_String_Escape(replace(replace(LongDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" visualDescription ":" ' + dbo.fn_String_Escape(replace(replace(VisualDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" publishedProvenance ":" ' + dbo.fn_String_Escape(replace(replace(PublishedProvenance, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" ensembleIndex ":" ' + dbo.fn_String_Escape(replace(replace(EnsembleIndex, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" primaryImageAltText ":" ' + dbo.fn_String_Escape(replace(replace(PrimaryImageAltText, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" audioTour ":" ' + dbo.fn_String_Escape(replace(replace(AudioTour, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
         
-        + ',' + '{'
-        + '"objectId":"'+CAST(ObjectID AS nvarchar(max)) + '",'
-        + COALESCE('"objectNumber":"' + ObjectNumber + '",','')
-        + COALESCE('"title":"' + dbo.fn_String_Escape(replace(replace(Title, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-        + COALESCE('"classification":"'+ Classification + '",','')
-		+ COALESCE('"onView":"'+ CAST(OnView AS nvarchar(max)) + '",','')
-        + COALESCE('"beginDate":"'+ CAST(BeginDate AS nvarchar(max)) + '",','')
-		+ COALESCE('"endDate":"'+ CAST(EndDate AS nvarchar(max)) + '",','')
-		+ COALESCE('"dated":"' + Dated + '",','')
-		+ COALESCE('"period":"' + Period + '",','')
-		+ COALESCE('"culture":"' + Culture + '",','')
-		+ COALESCE('"medium":"' + Medium + '",','')
-		+ COALESCE('"dimensions":"' + dbo.fn_String_Escape(replace(replace(Dimensions, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"ImagecreditLine":"' + dbo.fn_String_Escape(replace(replace(ImageCreditLine, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"copyrightStatus":"' + CopyrightStatus + '",','')
-		+ COALESCE('"copyrightsTypeID":"' + CAST(CopyrightsTypeID AS nvarchar(max)) + '",','')
-		+ COALESCE('"creditLine":"' + dbo.fn_String_Escape(replace(replace(CreditLine, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"copyright":"' + dbo.fn_String_Escape(replace(replace(Copyright, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 
-		+ COALESCE('"site":"' + Site + '",','')
-		+ COALESCE('"room":"' + Room + '",','')
-		+ COALESCE('"wall":"' + Wall + '",','')
-		+ COALESCE('"homeLocation":"' + HomeLocation + '",','')
-		+ COALESCE('"marks":"' + dbo.fn_String_Escape(replace(replace(Marks, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"inscriptions":"' + dbo.fn_String_Escape(replace(replace(Inscriptions, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"exhibitionHistory":"' + dbo.fn_String_Escape(replace(replace(ExhibitionHistory, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"bibliography":"' + dbo.fn_String_Escape(replace(replace(Bibliography, '\' , '\\'),CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 		
-		+ COALESCE('"shortDescription":"' + dbo.fn_String_Escape(replace(replace(ShortDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"longDescription":"' + dbo.fn_String_Escape(replace(replace(LongDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"visualDescription":"' + dbo.fn_String_Escape(replace(replace(VisualDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"publishedProvenance":"' + dbo.fn_String_Escape(replace(replace(PublishedProvenance, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"ensembleIndex":"' + dbo.fn_String_Escape(replace(replace(EnsembleIndex, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"primaryImageAltText":"' + dbo.fn_String_Escape(replace(replace(PrimaryImageAltText, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-		+ COALESCE('"audioTour":"' + dbo.fn_String_Escape(replace(replace(AudioTour, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-        
-		+ COALESCE('"mediaName":"' + MediaFile + '",','')
-		+ COALESCE('"mediaView":"' + MediaView + '",','')
-		+ COALESCE('"mediaDescription":"' + dbo.fn_String_Escape(replace(replace(MediaDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
-        + COALESCE('"publicAccess":"'+CAST(PublicAccess AS nvarchar(max)) + '",','')
-		+ COALESCE('"isPrimary":"'+CAST(IsPrimary AS nvarchar(max)) + '",','')
-		+ COALESCE('"photographerName":"' + PhotographerName + '",','')
-		+ COALESCE('"mediaRole":"' + MediaRole + '",','')  
-		+ COALESCE('"publicCaption":"' + dbo.fn_String_Escape(replace(replace(PublicCaption, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 
-		+ COALESCE('"renditionDate":"' + RenditionDate + '",','') 
-		+ COALESCE('"technique":"' + dbo.fn_String_Escape(replace(replace(Technique, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 
-		+ COALESCE('"renditionNumber":"' + RenditionNumber + '",','')
+		+ COALESCE('" mediaName ":" ' + MediaFile + ' ",','')
+		+ COALESCE('" mediaView ":" ' + MediaView + ' ",','')
+		+ COALESCE('" mediaDescription ":" ' + dbo.fn_String_Escape(replace(replace(MediaDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+        + COALESCE('" publicAccess ":" '+CAST(PublicAccess AS nvarchar(max)) + ' ",','')
+		+ COALESCE('" isPrimary ":" '+CAST(IsPrimary AS nvarchar(max)) + ' ",','')
+		+ COALESCE('" photographerName ":" ' + PhotographerName + ' ",','')
+		+ COALESCE('" mediaRole ":" ' + MediaRole + ' ",','')  
+		+ COALESCE('" publicCaption ":" ' + dbo.fn_String_Escape(replace(replace(PublicCaption, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 
+		+ COALESCE('" renditionDate ":" ' + RenditionDate + ' ",','') 
+		+ COALESCE('" technique ":" ' + dbo.fn_String_Escape(replace(replace(Technique, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 
+		+ COALESCE('" renditionNumber ":" ' + RenditionNumber + ' ",','')
 		/* Constituent (Artist) Information */
 		+ COALESCE(dbo.fn_ConstitJSON(@ObjectID) + '','' )
 		 + '}' 
@@ -182,5 +309,3 @@ INNER JOIN Constituents cts ON cn.ConstituentID = cts.ConstituentID and cts.Acti
 	 insert into TextEntries (TableID, ID, TextTypeID, TextStatusID, LoginID, EnteredDate, TextEntryHTML, TextEntry)
 	 values (108, @ObjectID, 67, 0, 'dnune', GetDate(), @return_value, @return_value)
 	 End
-
-

--- a/storedProcedures/SP_BF_OnlineCollectionPayload.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayload.sql
@@ -1,280 +1,152 @@
 USE [TMS]
 GO
-	/****** Object:  StoredProcedure [dbo].[SP_BF_OnlineCollectionPayload]    Script Date: 12/19/2022 9:00:56 PM ******/
-SET
-	ANSI_NULLS ON
+/****** Object:  StoredProcedure [dbo].[SP_BF_OnlineCollectionPayload]    Script Date: 12/19/2022 9:00:56 PM ******/
+SET ANSI_NULLS ON
 GO
-SET
-	QUOTED_IDENTIFIER ON
+SET QUOTED_IDENTIFIER ON
 GO
-	ALTER PROCEDURE [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID nvarchar(max) AS BEGIN;
 
--- Creates our `tempImage` table
-CREATE TABLE #tempImage(
-ObjectID int,
-ObjectNumber nvarchar(64),
-Title nvarchar(450),
-Classification nvarchar(64),
-OnView smallint,
-BeginDate int,
-EndDate int,
-Dated nvarchar(255),
-Period nvarchar(120),
-Culture nvarchar(120),
-Medium nvarchar(max),
-Dimensions nvarchar(max),
-ImageCreditLine nvarchar(max),
-Marks nvarchar(max),
-Inscriptions nvarchar(max),
-ExhibitionHistory nvarchar(max),
-Bibliography nvarchar(max),
-CopyrightStatus nvarchar(48),
-CopyrightsTypeID int,
-CreditLine nvarchar(max),
-copyright nvarchar(max),
-ShortDescription nvarchar(max),
-LongDescription nvarchar(max),
-VisualDescription nvarchar(max),
-PublishedProvenance nvarchar(max),
-EnsembleIndex nvarchar(max),
-PrimaryImageAltText nvarchar(max),
-AudioTour nvarchar(max),
-Site nvarchar(128),
-Room nvarchar(128),
-Wall nvarchar(64),
-HomeLocation nvarchar(512),
-MediaFile nvarchar(450),
-MediaView nvarchar(64),
-MediaDescription nvarchar(max),
-PublicAccess smallint,
-ISPrimary smallint,
-PhotographerName nvarchar(450),
-MediaRole nvarchar(32),
-PublicCaption nvarchar(max),
-RenditionDate nvarchar(19),
-Technique nvarchar(255),
-RenditionNumber nvarchar(64)
-);
+ALTER PROCEDURE [dbo].[SP_BF_OnlineCollectionPayload] 
+	   @ObjectID nvarchar(max) 
+AS
+BEGIN
 
-/**
- * SET NOCOUNT ON added to prevent extra result sets FROM
- * interfering with SELECT statements.
- */
-SET
-	NOCOUNT ON;
-
-INSERT INTO
-	#tempImage	
-SELECT
-	DISTINCT O.ObjectID,
-	O.ObjectNumber,
-	O.Title,
-	Cs.Classification,
-	O.OnView,
-	O.DateBegin,
-	O.DateEnd,
-	O.Dated,
-	Oc.Period,
-	Oc.Culture,
-	O.Medium,
-	O.Dimensions,
-	O.creditLine,
-	O.Markings,
-	O.Inscribed,
-	CASE
-		WHEN O.Exhibitions IS NOT NULL then '<p>' + REPLACE(
-			O.Exhibitions,
-			char(13) + char(10) + char(13) + char(10),
-			'</p><p>'
-		) + '</p>'
-		ELSE O.Exhibitions
-	END AS Exhibitions,
-	CASE
-		WHEN O.bibliography IS NOT NULL then '<p>' + REPLACE(
-			O.bibliography,
-			char(13) + char(10) + char(13) + char(10),
-			'</p><p>'
-		) + '</p>'
-		ELSE O.bibliography
-	END AS bibliography,
-	ort.ObjRightsType,
-	obr.ObjRightsTypeID,
-	obr.CreditLineRepro,
-	obr.Copyright,
-	tes.TextEntryHTML,
-	tel.TextEntryHTML,
-	tev.TextEntryHTML,
-	tep.TextEntryHTML,
-	teei.TextEntryHTML,
-	tepiat.TextEntryHTML,
-	teat.TextEntryHTML,
-	l.site,
-	l.Room,
-	l.UnitType,
-	l.LocationString,
-	mf.FileName,
-	mm.MediaView,
-	mm.Description,
-	mm.PublicAccess,
-	x.PrimaryDisplay,
-	conxref1.DisplayName,
-	conxref1.Role,
-	mm.PublicCaption,
-	mr.RenditionDate,
-	mr.Technique,
-	mr.RenditionNumber
-FROM
-	Objects O
+create table #tempImage(ObjectID int, ObjectNumber nvarchar(64), Title nvarchar(450), Classification nvarchar(64),
+ OnView smallint, BeginDate int, EndDate int, Dated nvarchar(255), Period nvarchar(120), Culture nvarchar(120), 
+ Medium nvarchar(max), Dimensions nvarchar(max) , ImageCreditLine nvarchar(max), Marks nvarchar(max), Inscriptions nvarchar(max), 
+ ExhibitionHistory nvarchar(max), Bibliography nvarchar(max), CopyrightStatus nvarchar(48), CopyrightsTypeID int,
+ CreditLine nvarchar(max), copyright nvarchar(max), ShortDescription nvarchar(max), 
+ LongDescription nvarchar(max), VisualDescription nvarchar(max), PublishedProvenance nvarchar(max), 
+ EnsembleIndex nvarchar(max), PrimaryImageAltText nvarchar(max), AudioTour nvarchar(max), Site nvarchar(128), 
+ Room nvarchar(128), Wall nvarchar(64), HomeLocation nvarchar(512), MediaFile nvarchar(450), MediaView nvarchar(64),
+ MediaDescription nvarchar(max), PublicAccess smallint, ISPrimary smallint, PhotographerName nvarchar(450),MediaRole nvarchar(32), 
+ PublicCaption nvarchar(max),RenditionDate nvarchar(19), Technique nvarchar(255), RenditionNumber nvarchar(64) ) 
+	-- SET NOCOUNT ON added to prevent extra result sets from
+	-- interfering with SELECT statements.
+	SET NOCOUNT ON;
+    -- Insert statements for procedure here
+	insert into #tempImage	SELECT distinct
+	O.ObjectID, O.ObjectNumber, O.Title, Cs.Classification, O.OnView, O.DateBegin, O.DateEnd, O.Dated, Oc.Period, Oc.Culture, 
+	O.Medium, O.Dimensions, O.creditLine, O.Markings, O.Inscribed, 
+	case  when O.Exhibitions IS NOT NULL
+	        then '<p>' + REPLACE(O.Exhibitions,char(13)+char(10)+char(13)+char(10),'</p><p>') + '</p>'
+	        else O.Exhibitions end as Exhibitions,
+	case  when O.bibliography IS NOT NULL
+	        then '<p>' + REPLACE(O.bibliography,char(13)+char(10)+char(13)+char(10),'</p><p>') + '</p>'
+	        else O.bibliography end as bibliography, 
+	ort.ObjRightsType, obr.ObjRightsTypeID , obr.CreditLineRepro, obr.Copyright,
+	tes.TextEntryHTML, tel.TextEntryHTML, tev.TextEntryHTML, tep.TextEntryHTML, teei.TextEntryHTML, tepiat.TextEntryHTML, 
+	teat.TextEntryHTML, l.site, l.Room, l.UnitType, l.LocationString, mf.FileName , mm.MediaView, mm.Description, mm.PublicAccess,
+	x.PrimaryDisplay, conxref1.DisplayName, conxref1.Role, mm.PublicCaption, mr.RenditionDate, mr.Technique, mr.RenditionNumber
+	from Objects O 
 	/* Classification */
 	INNER JOIN ClassificationXRefs CXR ON O.ObjectID = CXR.Id
-	INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId
+    INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId
 	/* Period, Culture */
 	INNER JOIN ObjContext Oc ON Oc.ObjectID = O.ObjectID
-	/* CopyrightStatus, coyrightsstatusid, CreditLineReproduction AND copyright */
+	/* CopyrightStatus, coyrightsstatusid, CreditLineReproduction and copyright */
 	INNER JOIN ObjRights obr ON obr.OBJECTID = O.ObjectID
-	INNER JOIN ObjRightsTypes Ort ON Ort.ObjRightsTypeID = Obr.ObjRightsTypeID
+	INNER JOIN ObjRightsTypes Ort on Ort.ObjRightsTypeID = Obr.ObjRightsTypeID
 	/*text Entries - short description, long description, visual description, published provenance,
-	 EnsembleIndex, PrimaryImageAltTxt AND AudioTour */
-	LEFT OUTER JOIN TextEntries tes ON tes.id = O.ObjectID
-	AND tes.Texttypeid = 48
-	LEFT OUTER JOIN TextEntries tel ON tel.id = O.ObjectID
-	AND tel.Texttypeid = 49
-	LEFT OUTER JOIN TextEntries tev ON tev.id = O.ObjectID
-	AND tev.Texttypeid = 50
-	LEFT OUTER JOIN TextEntries tep ON tep.id = O.ObjectID
-	AND tep.Texttypeid = 55
-	LEFT OUTER JOIN TextEntries teei ON teei.id = O.ObjectID
-	AND teei.Texttypeid = 57
-	LEFT OUTER JOIN TextEntries tepiat ON tepiat.id = O.ObjectID
-	AND tepiat.Texttypeid = 54
-	LEFT OUTER JOIN TextEntries teat ON teat.id = O.ObjectID
-	AND teat.Texttypeid = 32
+	EnsembleIndex, PrimaryImageAltTxt and AudioTour */
+	LEFT OUTER JOIN TextEntries tes on tes.id = O.ObjectID and tes.Texttypeid = 48
+	LEFT OUTER JOIN TextEntries tel on tel.id = O.ObjectID and tel.Texttypeid = 49
+	LEFT OUTER JOIN TextEntries tev on tev.id = O.ObjectID and tev.Texttypeid = 50
+	LEFT OUTER JOIN TextEntries tep on tep.id = O.ObjectID and tep.Texttypeid = 55 
+	LEFT OUTER JOIN TextEntries teei on teei.id = O.ObjectID and teei.Texttypeid = 57 
+	LEFT OUTER JOIN TextEntries tepiat on tepiat.id = O.ObjectID and tepiat.Texttypeid = 54 
+	LEFT OUTER JOIN TextEntries teat on teat.id = O.ObjectID and teat.Texttypeid = 32 
 	/* site, room, wall, homelocation */
-	INNER JOIN objcomponents obc ON o.objectID = obc.ObjectID
-	INNER JOIN locations l ON obc.HomeLocationID = l.LocationID
-	JOIN (
-		SELECT
-			mx.TableID,
-			mx.MediaMasterID,
-			conds.ID,
-			mx.PrimaryDisplay
-		FROM
-			condLineItems cli
-			JOIN conditions conds ON (conds.ConditionID = cli.ConditionID)
-			JOIN mediaxrefs mx ON (
-				mx.id = cli.CondLineItemID
-				AND mx.tableID = 97
-			)
-		UNION
-		(
-			SELECT
-				mx.TableID,
-				mx.MediaMasterID,
-				o.objectID,
-				mx.PrimaryDisplay
-			FROM
-				mediaxrefs mx
-				JOIN Objects o ON (
-					mx.id = o.ObjectID
-					AND mx.tableID = 108
-				)
-		)
-	) x ON x.ID = o.ObjectID
-	/* Photographer */
-	INNER JOIN MediaMaster mm On x.MediaMasterID = mm.MediaMasterID
-	INNER JOIN MediaRenditions mr ON (
-		mm.MediaMasterID = mr.MediaMasterID
-		AND mm.PrimaryRendID = mr.RenditionID
-	)
-	left JOIN MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
-	JOIN (
-		SELECT
-			const.DisplayName,
-			r.Role,
-			cx.ID,
-			cx.RoleTypeID,
-			cx.RoleID
-		FROM
-			ConXrefs cx
-			JOIN Roles r ON (r.RoleID = cx.RoleID)
-			JOIN (
-				SELECT
-					cts.DisplayName,
-					cxd.ConXrefID,
-					cxd.UnMasked
-				FROM
-					ConAltNames cn
-					JOIN Constituents cts ON (
-						cn.ConstituentID = cts.ConstituentID
-						/*AND cts.Active = 1*/
-					)
-					JOIN ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId)
-			) const ON (
-				cx.ConXrefID = const.ConXrefID
-				AND const.UnMasked = 1
-			)
-	) conxref1 ON (
-		mr.RenditionID = conxref1.ID
-		AND conxref1.RoleTypeID = 11
-		AND conxref1.RoleID = 11
-	)
-WHERE
-	O.ObjectID = @ObjectID;
+	INNER JOIN objcomponents obc on o.objectID = obc.ObjectID 	 
+    INNER JOIN locations l on obc.HomeLocationID  = l.LocationID
+	
+	 join 
+	 (select mx.TableID, mx.MediaMasterID, conds.ID, mx.PrimaryDisplay from condLineItems cli 
+	 join conditions conds on (conds.ConditionID = cli.ConditionID)
+	 join mediaxrefs mx on (mx.id = cli.CondLineItemID and mx.tableID = 97)
+	 union 
+	 (select mx.TableID, mx.MediaMasterID, o.objectID, mx.PrimaryDisplay from mediaxrefs mx  join Objects o on (mx.id = o.ObjectID and mx.tableID = 108) ))x
+  on x.ID = o.ObjectID
 
-DECLARE @return_value nvarchar(max)
-SET
-	@return_value = (
-		SELECT
-			'{' + '"objectRecord":' + '[' + STUFF(
-				(
-					SELECT
-						+ ',' + '{' + '"objectId":"' + CAST(ObjectID AS nvarchar(max)) + '",' + COALESCE('"objectNumber":"' + ObjectNumber + '",', '') + COALESCE(
-							'"title":"' + dbo.fn_String_Escape(
-								replace(
-									replace(
-										Title,
-										'\' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-        + COALESCE('" classification ":" '+ Classification + ' ",','')
-		+ COALESCE('" onView ":" '+ CAST(OnView AS nvarchar(max)) + ' ",','')
-        + COALESCE('" beginDate ":" '+ CAST(BeginDate AS nvarchar(max)) + ' ",','')
-		+ COALESCE('" endDate ":" '+ CAST(EndDate AS nvarchar(max)) + ' ",','')
-		+ COALESCE('" dated ":" ' + Dated + ' ",','')
-		+ COALESCE('" period ":" ' + Period + ' ",','')
-		+ COALESCE('" culture ":" ' + Culture + ' ",','')
-		+ COALESCE('" medium ":" ' + Medium + ' ",','')
-		+ COALESCE('" dimensions ":" ' + dbo.fn_String_Escape(replace(replace(Dimensions, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" ImagecreditLine ":" ' + dbo.fn_String_Escape(replace(replace(ImageCreditLine, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" copyrightStatus ":" ' + CopyrightStatus + ' ",','')
-		+ COALESCE('" copyrightsTypeID ":" ' + CAST(CopyrightsTypeID AS nvarchar(max)) + ' ",','')
-		+ COALESCE('" creditLine ":" ' + dbo.fn_String_Escape(replace(replace(CreditLine, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" copyright ":" ' + dbo.fn_String_Escape(replace(replace(Copyright, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 
-		+ COALESCE('" site ":" ' + Site + ' ",','')
-		+ COALESCE('" room ":" ' + Room + ' ",','')
-		+ COALESCE('" wall ":" ' + Wall + ' ",','')
-		+ COALESCE('" homeLocation ":" ' + HomeLocation + ' ",','')
-		+ COALESCE('" marks ":" ' + dbo.fn_String_Escape(replace(replace(Marks, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" inscriptions ":" ' + dbo.fn_String_Escape(replace(replace(Inscriptions, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" exhibitionHistory ":" ' + dbo.fn_String_Escape(replace(replace(ExhibitionHistory, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" bibliography ":" ' + dbo.fn_String_Escape(replace(replace(Bibliography, ' \ ' , ' \ \ '),CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 		
-		+ COALESCE('" shortDescription ":" ' + dbo.fn_String_Escape(replace(replace(ShortDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" longDescription ":" ' + dbo.fn_String_Escape(replace(replace(LongDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" visualDescription ":" ' + dbo.fn_String_Escape(replace(replace(VisualDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" publishedProvenance ":" ' + dbo.fn_String_Escape(replace(replace(PublishedProvenance, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" ensembleIndex ":" ' + dbo.fn_String_Escape(replace(replace(EnsembleIndex, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" primaryImageAltText ":" ' + dbo.fn_String_Escape(replace(replace(PrimaryImageAltText, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" audioTour ":" ' + dbo.fn_String_Escape(replace(replace(AudioTour, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+	/* Photographer */	
+INNER JOIN MediaMaster mm On x.MediaMasterID = mm.MediaMasterID 
+INNER JOIN MediaRenditions mr ON (mm.MediaMasterID = mr.MediaMasterID and mm.PrimaryRendID = mr.RenditionID )
+left join MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
+join (select const.DisplayName,r.Role, cx.ID,cx.RoleTypeID,cx.RoleID  from ConXrefs cx join Roles r on (r.RoleID = cx.RoleID)
+                
+				join (select cts.DisplayName, cxd.ConXrefID, cxd.UnMasked  from ConAltNames cn
+                join Constituents cts on (cn.ConstituentID = cts.ConstituentID /*and cts.Active = 1*/)
+        join ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId))const
+
+        ON (cx.ConXrefID = const.ConXrefID and const.UnMasked = 1))conxref1
+        ON (mr.RenditionID = conxref1.ID and conxref1.RoleTypeID = 11 and conxref1.RoleID = 11) 
+
+		WHERE O.ObjectID = @ObjectID 
+	
+	
+
+	
+	/* Photographer */	
+INNER JOIN MediaMaster mm On Mx.MediaMasterID = mm.MediaMasterID 
+INNER JOIN MediaRenditions mr ON mm.MediaMasterID = mr.MediaMasterID
+INNER JOIN ConXrefs cx ON  mr.RenditionID = cx.ID and cx.RoleTypeID = 11 and cx.RoleID = 11
+INNER JOIN MediaFiles mf ON mr.PrimaryFileID = mf.FileID
+INNER JOIN Roles r on r.RoleID = cx.RoleID
+INNER JOIN ConXrefDetails cxd ON cx.ConXrefID = cxd.ConXrefID and cxd.UnMasked = 1
+INNER JOIN ConAltNames cn ON cxd.NameID = cn.AltNameId
+INNER JOIN Constituents cts ON cn.ConstituentID = cts.ConstituentID and cts.Active = 1 
+	 WHERE O.ObjectID = @ObjectID */
+
+	DECLARE	@return_value nvarchar(max)
+
+  Set @return_value = (SELECT  '{' + '"objectRecord":' + '[' + STUFF((
+    SELECT
         
-		+ COALESCE('" mediaName ":" ' + MediaFile + ' ",','')
-		+ COALESCE('" mediaView ":" ' + MediaView + ' ",','')
-		+ COALESCE('" mediaDescription ":" ' + dbo.fn_String_Escape(replace(replace(MediaDescription, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-        + COALESCE('" publicAccess ":" '+CAST(PublicAccess AS nvarchar(max)) + ' ",','')
-		+ COALESCE('" isPrimary ":" '+CAST(IsPrimary AS nvarchar(max)) + ' ",','')
-		+ COALESCE('" photographerName ":" ' + PhotographerName + ' ",','')
-		+ COALESCE('" mediaRole ":" ' + MediaRole + ' ",','')  
-		+ COALESCE('" publicCaption ":" ' + dbo.fn_String_Escape(replace(replace(PublicCaption, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 
-		+ COALESCE('" renditionDate ":" ' + RenditionDate + ' ",','') 
-		+ COALESCE('" technique ":" ' + dbo.fn_String_Escape(replace(replace(Technique, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','') 
-		+ COALESCE('" renditionNumber ":" ' + RenditionNumber + ' ",','')
+        + ',' + '{'
+        + '"objectId":"'+CAST(ObjectID AS nvarchar(max)) + '",'
+        + COALESCE('"objectNumber":"' + ObjectNumber + '",','')
+        + COALESCE('"title":"' + dbo.fn_String_Escape(replace(replace(Title, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+        + COALESCE('"classification":"'+ Classification + '",','')
+		+ COALESCE('"onView":"'+ CAST(OnView AS nvarchar(max)) + '",','')
+        + COALESCE('"beginDate":"'+ CAST(BeginDate AS nvarchar(max)) + '",','')
+		+ COALESCE('"endDate":"'+ CAST(EndDate AS nvarchar(max)) + '",','')
+		+ COALESCE('"dated":"' + Dated + '",','')
+		+ COALESCE('"period":"' + Period + '",','')
+		+ COALESCE('"culture":"' + Culture + '",','')
+		+ COALESCE('"medium":"' + Medium + '",','')
+		+ COALESCE('"dimensions":"' + dbo.fn_String_Escape(replace(replace(Dimensions, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"ImagecreditLine":"' + dbo.fn_String_Escape(replace(replace(ImageCreditLine, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"copyrightStatus":"' + CopyrightStatus + '",','')
+		+ COALESCE('"copyrightsTypeID":"' + CAST(CopyrightsTypeID AS nvarchar(max)) + '",','')
+		+ COALESCE('"creditLine":"' + dbo.fn_String_Escape(replace(replace(CreditLine, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"copyright":"' + dbo.fn_String_Escape(replace(replace(Copyright, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 
+		+ COALESCE('"site":"' + Site + '",','')
+		+ COALESCE('"room":"' + Room + '",','')
+		+ COALESCE('"wall":"' + Wall + '",','')
+		+ COALESCE('"homeLocation":"' + HomeLocation + '",','')
+		+ COALESCE('"marks":"' + dbo.fn_String_Escape(replace(replace(Marks, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"inscriptions":"' + dbo.fn_String_Escape(replace(replace(Inscriptions, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"exhibitionHistory":"' + dbo.fn_String_Escape(replace(replace(ExhibitionHistory, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"bibliography":"' + dbo.fn_String_Escape(replace(replace(Bibliography, '\' , '\\'),CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 		
+		+ COALESCE('"shortDescription":"' + dbo.fn_String_Escape(replace(replace(ShortDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"longDescription":"' + dbo.fn_String_Escape(replace(replace(LongDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"visualDescription":"' + dbo.fn_String_Escape(replace(replace(VisualDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"publishedProvenance":"' + dbo.fn_String_Escape(replace(replace(PublishedProvenance, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"ensembleIndex":"' + dbo.fn_String_Escape(replace(replace(EnsembleIndex, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"primaryImageAltText":"' + dbo.fn_String_Escape(replace(replace(PrimaryImageAltText, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+		+ COALESCE('"audioTour":"' + dbo.fn_String_Escape(replace(replace(AudioTour, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+        
+		+ COALESCE('"mediaName":"' + MediaFile + '",','')
+		+ COALESCE('"mediaView":"' + MediaView + '",','')
+		+ COALESCE('"mediaDescription":"' + dbo.fn_String_Escape(replace(replace(MediaDescription, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','')
+        + COALESCE('"publicAccess":"'+CAST(PublicAccess AS nvarchar(max)) + '",','')
+		+ COALESCE('"isPrimary":"'+CAST(IsPrimary AS nvarchar(max)) + '",','')
+		+ COALESCE('"photographerName":"' + PhotographerName + '",','')
+		+ COALESCE('"mediaRole":"' + MediaRole + '",','')  
+		+ COALESCE('"publicCaption":"' + dbo.fn_String_Escape(replace(replace(PublicCaption, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 
+		+ COALESCE('"renditionDate":"' + RenditionDate + '",','') 
+		+ COALESCE('"technique":"' + dbo.fn_String_Escape(replace(replace(Technique, '\' , '\\'), CHAR(13)+CHAR(10), '\n'), 'json') + '",','') 
+		+ COALESCE('"renditionNumber":"' + RenditionNumber + '",','')
 		/* Constituent (Artist) Information */
 		+ COALESCE(dbo.fn_ConstitJSON(@ObjectID) + '','' )
 		 + '}' 
@@ -283,15 +155,16 @@ SET
     + ']' + '}' 
 	 );
 
-	 --SELECT @return_value 
+	 create table #tempvar(jsonvalue nvarchar(max));
 
-	 CREATE TABLE #tempvar(jsonvalue nvarchar(max));
-	 INSERT INTO #tempvar SELECT @return_value;
+	 insert into #tempvar select @return_value
 
-	  
 	 /*Delete Existing rows with TextTypeID 67 */
-	 DELETE FROM tms.dbo.TextEntries where TextTypeID = 67 AND ID = @ObjectID;
+	 delete from tms.dbo.TextEntries where TextTypeID = 67 and ID = @ObjectID
 
-	 /*Insert into Textentries */    
-	 INSERT INTO TextEntries (TableID, ID, TextTypeID, TextStatusID, LoginID, EnteredDate, TextEntryHTML, TextEntry)
-	 VALUES (108, @ObjectID, 67, 0, 'dnune', GetDate(), @return_value, @return_value)
+	 /*Insert into Textentries */
+	 insert into TextEntries (TableID, ID, TextTypeID, TextStatusID, LoginID, EnteredDate, TextEntryHTML, TextEntry)
+	 values (108, @ObjectID, 67, 0, 'dnune', GetDate(), @return_value, @return_value)
+	 End
+
+

--- a/storedProcedures/SP_BF_OnlineCollectionPayload.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayload.sql
@@ -26,7 +26,7 @@ create table #tempImage(ObjectID int, ObjectNumber nvarchar(64), Title nvarchar(
 	SET NOCOUNT ON;
     -- Insert statements for procedure here
 	insert into #tempImage	SELECT distinct
-	O.ObjectID, O.ObjectNumber, O.Title, Cs.Classification, O.OnView, O.DateBegin, O.DateEnd, O.Dated, Oc.Period, Oc.Culture, 
+	O.ObjectID, O.ObjectNumber, OT.Title, Cs.Classification, O.OnView, O.DateBegin, O.DateEnd, O.Dated, Oc.Period, Oc.Culture, 
 	O.Medium, O.Dimensions, O.creditLine, O.Markings, O.Inscribed, 
 	case  when O.Exhibitions IS NOT NULL
 	        then '<p>' + REPLACE(O.Exhibitions,char(13)+char(10)+char(13)+char(10),'</p><p>') + '</p>'
@@ -39,6 +39,13 @@ create table #tempImage(ObjectID int, ObjectNumber nvarchar(64), Title nvarchar(
 	teat.TextEntryHTML, l.site, l.Room, l.UnitType, l.LocationString, mf.FileName , mm.MediaView, mm.Description, mm.PublicAccess,
 	x.PrimaryDisplay, conxref1.DisplayName, conxref1.Role, mm.PublicCaption, mr.RenditionDate, mr.Technique, mr.RenditionNumber
 	from Objects O 
+	/** Object Titles */
+	INNER JOIN (
+	SELECT Title, ObjectID 
+	FROM ObjTitles 
+	WHERE ObjTitles.DisplayOrder = 1
+	) OT
+	ON O.ObjectID = OT.ObjectID
 	/* Classification */
 	INNER JOIN ClassificationXRefs CXR ON O.ObjectID = CXR.Id
     INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId

--- a/storedProcedures/SP_BF_OnlineCollectionPayload.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayload.sql
@@ -7,61 +7,66 @@ GO
 SET
 	QUOTED_IDENTIFIER ON
 GO
-	-- =============================================
-	-- Author:		<Author,,Name>
-	-- Create date: <Create Date,,>
-	-- Description:	<Description,,>
-	-- =============================================
-	ALTER PROCEDURE [dbo].[SP_BF_OnlineCollectionPayload] -- Add the parameters for the stored procedure here
-	@ObjectID nvarchar(max) AS BEGIN create table #tempImage(ObjectID int, ObjectNumber nvarchar(64), Title nvarchar(450), Classification nvarchar(64),
-	OnView smallint,
-	BeginDate int,
-	EndDate int,
-	Dated nvarchar(255),
-	Period nvarchar(120),
-	Culture nvarchar(120),
-	Medium nvarchar(max),
-	Dimensions nvarchar(max),
-	ImageCreditLine nvarchar(max),
-	Marks nvarchar(max),
-	Inscriptions nvarchar(max),
-	ExhibitionHistory nvarchar(max),
-	Bibliography nvarchar(max),
-	CopyrightStatus nvarchar(48),
-	CopyrightsTypeID int,
-	CreditLine nvarchar(max),
-	copyright nvarchar(max),
-	ShortDescription nvarchar(max),
-	LongDescription nvarchar(max),
-	VisualDescription nvarchar(max),
-	PublishedProvenance nvarchar(max),
-	EnsembleIndex nvarchar(max),
-	PrimaryImageAltText nvarchar(max),
-	AudioTour nvarchar(max),
-	Site nvarchar(128),
-	Room nvarchar(128),
-	Wall nvarchar(64),
-	HomeLocation nvarchar(512),
-	MediaFile nvarchar(450),
-	MediaView nvarchar(64),
-	MediaDescription nvarchar(max),
-	PublicAccess smallint,
-	ISPrimary smallint,
-	PhotographerName nvarchar(450),
-	MediaRole nvarchar(32),
-	PublicCaption nvarchar(max),
-	RenditionDate nvarchar(19),
-	Technique nvarchar(255),
-	RenditionNumber nvarchar(64)
-) -- SET NOCOUNT ON added to prevent extra result sets from
--- interfering with SELECT statements.
+	ALTER PROCEDURE [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID nvarchar(max) AS BEGIN;
+
+-- Creates our `tempImage` table
+CREATE TABLE #tempImage(
+ObjectID int,
+ObjectNumber nvarchar(64),
+Title nvarchar(450),
+Classification nvarchar(64),
+OnView smallint,
+BeginDate int,
+EndDate int,
+Dated nvarchar(255),
+Period nvarchar(120),
+Culture nvarchar(120),
+Medium nvarchar(max),
+Dimensions nvarchar(max),
+ImageCreditLine nvarchar(max),
+Marks nvarchar(max),
+Inscriptions nvarchar(max),
+ExhibitionHistory nvarchar(max),
+Bibliography nvarchar(max),
+CopyrightStatus nvarchar(48),
+CopyrightsTypeID int,
+CreditLine nvarchar(max),
+copyright nvarchar(max),
+ShortDescription nvarchar(max),
+LongDescription nvarchar(max),
+VisualDescription nvarchar(max),
+PublishedProvenance nvarchar(max),
+EnsembleIndex nvarchar(max),
+PrimaryImageAltText nvarchar(max),
+AudioTour nvarchar(max),
+Site nvarchar(128),
+Room nvarchar(128),
+Wall nvarchar(64),
+HomeLocation nvarchar(512),
+MediaFile nvarchar(450),
+MediaView nvarchar(64),
+MediaDescription nvarchar(max),
+PublicAccess smallint,
+ISPrimary smallint,
+PhotographerName nvarchar(450),
+MediaRole nvarchar(32),
+PublicCaption nvarchar(max),
+RenditionDate nvarchar(19),
+Technique nvarchar(255),
+RenditionNumber nvarchar(64)
+);
+
+/**
+ * SET NOCOUNT ON added to prevent extra result sets FROM
+ * interfering with SELECT statements.
+ */
 SET
 	NOCOUNT ON;
 
--- Insert statements for procedure here
-insert into
-	#tempImage	SELECT distinct
-	O.ObjectID,
+INSERT INTO
+	#tempImage	
+SELECT
+	DISTINCT O.ObjectID,
 	O.ObjectNumber,
 	O.Title,
 	Cs.Classification,
@@ -76,22 +81,22 @@ insert into
 	O.creditLine,
 	O.Markings,
 	O.Inscribed,
-	case
-		when O.Exhibitions IS NOT NULL then '<p>' + REPLACE(
+	CASE
+		WHEN O.Exhibitions IS NOT NULL then '<p>' + REPLACE(
 			O.Exhibitions,
 			char(13) + char(10) + char(13) + char(10),
 			'</p><p>'
 		) + '</p>'
-		else O.Exhibitions
-	end as Exhibitions,
-	case
-		when O.bibliography IS NOT NULL then '<p>' + REPLACE(
+		ELSE O.Exhibitions
+	END AS Exhibitions,
+	CASE
+		WHEN O.bibliography IS NOT NULL then '<p>' + REPLACE(
 			O.bibliography,
 			char(13) + char(10) + char(13) + char(10),
 			'</p><p>'
 		) + '</p>'
-		else O.bibliography
-	end as bibliography,
+		ELSE O.bibliography
+	END AS bibliography,
 	ort.ObjRightsType,
 	obr.ObjRightsTypeID,
 	obr.CreditLineRepro,
@@ -118,120 +123,105 @@ insert into
 	mr.RenditionDate,
 	mr.Technique,
 	mr.RenditionNumber
-from
+FROM
 	Objects O
 	/* Classification */
 	INNER JOIN ClassificationXRefs CXR ON O.ObjectID = CXR.Id
 	INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId
 	/* Period, Culture */
 	INNER JOIN ObjContext Oc ON Oc.ObjectID = O.ObjectID
-	/* CopyrightStatus, coyrightsstatusid, CreditLineReproduction and copyright */
+	/* CopyrightStatus, coyrightsstatusid, CreditLineReproduction AND copyright */
 	INNER JOIN ObjRights obr ON obr.OBJECTID = O.ObjectID
-	INNER JOIN ObjRightsTypes Ort on Ort.ObjRightsTypeID = Obr.ObjRightsTypeID
+	INNER JOIN ObjRightsTypes Ort ON Ort.ObjRightsTypeID = Obr.ObjRightsTypeID
 	/*text Entries - short description, long description, visual description, published provenance,
-	 EnsembleIndex, PrimaryImageAltTxt and AudioTour */
-	LEFT OUTER JOIN TextEntries tes on tes.id = O.ObjectID
-	and tes.Texttypeid = 48
-	LEFT OUTER JOIN TextEntries tel on tel.id = O.ObjectID
-	and tel.Texttypeid = 49
-	LEFT OUTER JOIN TextEntries tev on tev.id = O.ObjectID
-	and tev.Texttypeid = 50
-	LEFT OUTER JOIN TextEntries tep on tep.id = O.ObjectID
-	and tep.Texttypeid = 55
-	LEFT OUTER JOIN TextEntries teei on teei.id = O.ObjectID
-	and teei.Texttypeid = 57
-	LEFT OUTER JOIN TextEntries tepiat on tepiat.id = O.ObjectID
-	and tepiat.Texttypeid = 54
-	LEFT OUTER JOIN TextEntries teat on teat.id = O.ObjectID
-	and teat.Texttypeid = 32
+	 EnsembleIndex, PrimaryImageAltTxt AND AudioTour */
+	LEFT OUTER JOIN TextEntries tes ON tes.id = O.ObjectID
+	AND tes.Texttypeid = 48
+	LEFT OUTER JOIN TextEntries tel ON tel.id = O.ObjectID
+	AND tel.Texttypeid = 49
+	LEFT OUTER JOIN TextEntries tev ON tev.id = O.ObjectID
+	AND tev.Texttypeid = 50
+	LEFT OUTER JOIN TextEntries tep ON tep.id = O.ObjectID
+	AND tep.Texttypeid = 55
+	LEFT OUTER JOIN TextEntries teei ON teei.id = O.ObjectID
+	AND teei.Texttypeid = 57
+	LEFT OUTER JOIN TextEntries tepiat ON tepiat.id = O.ObjectID
+	AND tepiat.Texttypeid = 54
+	LEFT OUTER JOIN TextEntries teat ON teat.id = O.ObjectID
+	AND teat.Texttypeid = 32
 	/* site, room, wall, homelocation */
-	INNER JOIN objcomponents obc on o.objectID = obc.ObjectID
-	INNER JOIN locations l on obc.HomeLocationID = l.LocationID
-	join (
-		select
+	INNER JOIN objcomponents obc ON o.objectID = obc.ObjectID
+	INNER JOIN locations l ON obc.HomeLocationID = l.LocationID
+	JOIN (
+		SELECT
 			mx.TableID,
 			mx.MediaMasterID,
 			conds.ID,
 			mx.PrimaryDisplay
-		from
+		FROM
 			condLineItems cli
-			join conditions conds on (conds.ConditionID = cli.ConditionID)
-			join mediaxrefs mx on (
+			JOIN conditions conds ON (conds.ConditionID = cli.ConditionID)
+			JOIN mediaxrefs mx ON (
 				mx.id = cli.CondLineItemID
-				and mx.tableID = 97
+				AND mx.tableID = 97
 			)
-		union
+		UNION
 		(
-			select
+			SELECT
 				mx.TableID,
 				mx.MediaMasterID,
 				o.objectID,
 				mx.PrimaryDisplay
-			from
+			FROM
 				mediaxrefs mx
-				join Objects o on (
+				JOIN Objects o ON (
 					mx.id = o.ObjectID
-					and mx.tableID = 108
+					AND mx.tableID = 108
 				)
 		)
-	) x on x.ID = o.ObjectID
+	) x ON x.ID = o.ObjectID
 	/* Photographer */
 	INNER JOIN MediaMaster mm On x.MediaMasterID = mm.MediaMasterID
 	INNER JOIN MediaRenditions mr ON (
 		mm.MediaMasterID = mr.MediaMasterID
-		and mm.PrimaryRendID = mr.RenditionID
+		AND mm.PrimaryRendID = mr.RenditionID
 	)
-	left join MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
-	join (
-		select
+	left JOIN MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
+	JOIN (
+		SELECT
 			const.DisplayName,
 			r.Role,
 			cx.ID,
 			cx.RoleTypeID,
 			cx.RoleID
-		from
+		FROM
 			ConXrefs cx
-			join Roles r on (r.RoleID = cx.RoleID)
-			join (
-				select
+			JOIN Roles r ON (r.RoleID = cx.RoleID)
+			JOIN (
+				SELECT
 					cts.DisplayName,
 					cxd.ConXrefID,
 					cxd.UnMasked
-				from
+				FROM
 					ConAltNames cn
-					join Constituents cts on (
+					JOIN Constituents cts ON (
 						cn.ConstituentID = cts.ConstituentID
-						/*and cts.Active = 1*/
+						/*AND cts.Active = 1*/
 					)
-					join ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId)
+					JOIN ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId)
 			) const ON (
 				cx.ConXrefID = const.ConXrefID
-				and const.UnMasked = 1
+				AND const.UnMasked = 1
 			)
 	) conxref1 ON (
 		mr.RenditionID = conxref1.ID
-		and conxref1.RoleTypeID = 11
-		and conxref1.RoleID = 11
+		AND conxref1.RoleTypeID = 11
+		AND conxref1.RoleID = 11
 	)
 WHERE
-	O.ObjectID = @ObjectID
-	/** INNER JOIN MediaXRefs mx On mx.ID = o.ObjectID And mx.TableID = 108 and Mx.PrimaryDisplay = 1
-	 INNER JOIN MediaMaster mm On Mx.MediaMasterID = mm.MediaMasterID
-	 INNER JOIN MediaRenditions mr ON mm.MediaMasterID = mr.MediaMasterID
-	 INNER JOIN ConXrefs cx ON mr.RenditionID = cx.ID
-	 and cx.RoleTypeID = 11
-	 and cx.RoleID = 11
-	 INNER JOIN MediaFiles mf ON mr.PrimaryFileID = mf.FileID
-	 INNER JOIN Roles r on r.RoleID = cx.RoleID
-	 INNER JOIN ConXrefDetails cxd ON cx.ConXrefID = cxd.ConXrefID
-	 and cxd.UnMasked = 1
-	 INNER JOIN ConAltNames cn ON cxd.NameID = cn.AltNameId
-	 INNER JOIN Constituents cts ON cn.ConstituentID = cts.ConstituentID
-	 and cts.Active = 1
-	 WHERE
-	 O.ObjectID = @ObjectID * /
-	 /* Select * from #tempImage */
-	DECLARE @return_value nvarchar(max)
+	O.ObjectID = @ObjectID;
+
+DECLARE @return_value nvarchar(max)
 SET
 	@return_value = (
 		SELECT
@@ -293,19 +283,15 @@ SET
     + ']' + '}' 
 	 );
 
-	 --select @return_value 
+	 --SELECT @return_value 
 
-	 create table #tempvar(jsonvalue nvarchar(max));
+	 CREATE TABLE #tempvar(jsonvalue nvarchar(max));
+	 INSERT INTO #tempvar SELECT @return_value;
 
-	 insert into #tempvar select @return_value
-
-	  /* select * from #tempvar */
 	  
 	 /*Delete Existing rows with TextTypeID 67 */
-	 delete from tms.dbo.TextEntries where TextTypeID = 67 and ID = @ObjectID
+	 DELETE FROM tms.dbo.TextEntries where TextTypeID = 67 AND ID = @ObjectID;
 
-	 /*Insert into Textentries */
-
-	 insert into TextEntries (TableID, ID, TextTypeID, TextStatusID, LoginID, EnteredDate, TextEntryHTML, TextEntry)
-	 values (108, @ObjectID, 67, 0, 'dnune', GetDate(), @return_value, @return_value)
-	 End
+	 /*Insert into Textentries */    
+	 INSERT INTO TextEntries (TableID, ID, TextTypeID, TextStatusID, LoginID, EnteredDate, TextEntryHTML, TextEntry)
+	 VALUES (108, @ObjectID, 67, 0, 'dnune', GetDate(), @return_value, @return_value)

--- a/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
@@ -28,13 +28,19 @@ SET
 INSERT INTO
 	#tempObjects	
 SELECT
-	DISTINCT O.ObjectID,
-	O.ObjectNumber,
-	O.Title,
-	O.Dated,
-	O.Description
+    DISTINCT O.ObjectID,
+    O.ObjectNumber,
+    OT.Title,
+    O.Dated,
+    O.Description
 FROM
-	Objects O
+    Objects O
+INNER JOIN (
+	SELECT Title, ObjectID 
+	FROM ObjTitles 
+	WHERE ObjTitles.DisplayOrder = 1
+	) OT
+	ON O.ObjectID = OT.ObjectID
 WHERE
 	O.ObjectID = @ObjectID;
 

--- a/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
@@ -50,9 +50,9 @@ SET
 								replace(
 									replace(
 										Title,
-										'\' , '\\'), CHAR(13)+CHAR(10), '\n '), ' json ') + '",','')
+										'\' , '\\'), CHAR(13)+CHAR(10), '\n '), 'json') + '",','')
 		+ COALESCE('"dated":" ' + Dated + '",','')
-		+ COALESCE('"description":" ' + dbo.fn_String_Escape(replace(replace(COALESCE(Description, ''), '\' , '\\'), CHAR(13)+CHAR(10), '\n '), ' json ') + '"','')
+		+ COALESCE('"description":" ' + dbo.fn_String_Escape(replace(replace(COALESCE(Description, ''), '\' , '\\'), CHAR(13)+CHAR(10), '\n '), 'json') + '"','')
 		 + '}' 
     FROM #tempObjects
     FOR XML PATH(''), TYPE).value('.', 'nvarchar(MAX)'),1,1,'')

--- a/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
@@ -32,7 +32,7 @@ SELECT
 	O.ObjectNumber,
 	O.Title,
 	O.Dated,
-	O.Description,
+	O.Description
 FROM
 	Objects O
 WHERE
@@ -51,8 +51,8 @@ SET
 									replace(
 										Title,
 										'\' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('" dated ":" ' + Dated + ' ",','')
-		+ COALESCE('" description ":" ' + dbo.fn_String_Escape(replace(replace(Description, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('"dated ":" ' + Dated + ' ",','')
+		+ COALESCE('"description ":" ' + dbo.fn_String_Escape(replace(replace(COALESCE(Description, ''), ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' "','')
 		 + '}' 
     FROM #tempObjects
     FOR XML PATH(''), TYPE).value('.', 'nvarchar(MAX)'),1,1,'')

--- a/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
@@ -50,9 +50,9 @@ SET
 								replace(
 									replace(
 										Title,
-										'\' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
-		+ COALESCE('"dated ":" ' + Dated + ' ",','')
-		+ COALESCE('"description ":" ' + dbo.fn_String_Escape(replace(replace(COALESCE(Description, ''), ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' "','')
+										'\' , '\\'), CHAR(13)+CHAR(10), '\n '), ' json ') + '",','')
+		+ COALESCE('"dated":" ' + Dated + '",','')
+		+ COALESCE('"description":" ' + dbo.fn_String_Escape(replace(replace(COALESCE(Description, ''), '\' , '\\'), CHAR(13)+CHAR(10), '\n '), ' json ') + '"','')
 		 + '}' 
     FROM #tempObjects
     FOR XML PATH(''), TYPE).value('.', 'nvarchar(MAX)'),1,1,'')

--- a/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
+++ b/storedProcedures/SP_BF_OnlineCollectionPayloadArchives.sql
@@ -1,0 +1,73 @@
+USE [TMS]
+GO
+	/****** Object:  StoredProcedure [dbo].[SP_BF_OnlineCollectionPayload]    Script Date: 12/19/2022 9:00:56 PM ******/
+SET
+	ANSI_NULLS ON
+GO
+SET
+	QUOTED_IDENTIFIER ON
+GO
+	ALTER PROCEDURE [dbo].[SP_BF_OnlineCollectionPayloadArchives] @ObjectID nvarchar(max) AS BEGIN;
+
+-- Creates our `tempObjects` table
+CREATE TABLE #tempObjects(
+ObjectID int,
+ObjectNumber nvarchar(64),
+Title nvarchar(450),
+Dated nvarchar(255),
+Description nvarchar(max)
+);
+
+/**
+ * SET NOCOUNT ON added to prevent extra result sets FROM
+ * interfering with SELECT statements.
+ */
+SET
+	NOCOUNT ON;
+
+INSERT INTO
+	#tempObjects	
+SELECT
+	DISTINCT O.ObjectID,
+	O.ObjectNumber,
+	O.Title,
+	O.Dated,
+	O.Description,
+FROM
+	Objects O
+WHERE
+	O.ObjectID = @ObjectID;
+
+DECLARE @return_value nvarchar(max)
+SET
+	@return_value = (
+		SELECT
+			'{' + '"objectRecord":' + '[' + STUFF(
+				(
+					SELECT
+						+ ',' + '{' + '"objectId":"' + CAST(ObjectID AS nvarchar(max)) + '",' + COALESCE('"objectNumber":"' + ObjectNumber + '",', '') + COALESCE(
+							'"title":"' + dbo.fn_String_Escape(
+								replace(
+									replace(
+										Title,
+										'\' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		+ COALESCE('" dated ":" ' + Dated + ' ",','')
+		+ COALESCE('" description ":" ' + dbo.fn_String_Escape(replace(replace(Description, ' \ ' , ' \ \ '), CHAR(13)+CHAR(10), ' \ n '), ' json ') + ' ",','')
+		 + '}' 
+    FROM #tempObjects
+    FOR XML PATH(''), TYPE).value('.', 'nvarchar(MAX)'),1,1,'')
+    + ']' + '}' 
+	 );
+
+	 --SELECT @return_value 
+
+	 CREATE TABLE #tempvar(jsonvalue nvarchar(max));
+	 INSERT INTO #tempvar SELECT @return_value;
+
+	  
+	 /*Delete Existing rows with TextTypeID 67 */
+	 DELETE FROM tms.dbo.TextEntries where TextTypeID = 67 AND ID = @ObjectID;
+
+	 /*Insert into Textentries */    
+	 INSERT INTO TextEntries (TableID, ID, TextTypeID, TextStatusID, LoginID, EnteredDate, TextEntryHTML, TextEntry)
+	 VALUES (108, @ObjectID, 67, 0, 'dnune', GetDate(), @return_value, @return_value)

--- a/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
+++ b/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
@@ -157,9 +157,9 @@ FROM
 	OPEN objectCursor FETCH NEXT
 FROM
 	objectCursor INTO @ObjectID,
-	@RenditionExists WHILE @ @FETCH_STATUS = 0 BEGIN EXEC IF @RenditionExists = 1 [dbo].[SP_BF_OnlineCollectionPayloadArchives] @ObjectID;
+	@RenditionExists WHILE @ @FETCH_STATUS = 0 BEGIN EXEC IF @RenditionExists = 1 [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID;
 
-ELSE [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID;
+ELSE [dbo].[SP_BF_OnlineCollectionPayloadArchives] @ObjectID;
 
 FETCH NEXT
 FROM

--- a/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
+++ b/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
@@ -144,28 +144,27 @@ WHERE
  * Runs the stored procedure `SP_BF_OnlineCollectionPayload` for each TemporaryObjectID in our `temporaryObjectIDs` table
  * which should at this point contain ObjectID's for Media Rendition objects, and Archives
  */
-DECLARE @ObjectID int;
+DECLARE @ObjectID INT;
 
 DECLARE @RenditionExists BIT;
 
 DECLARE objectCursor CURSOR FOR
+
 SELECT
 	TemporaryObjectID,
 	RenditionExists
 FROM
-	#temporaryObjectIDs
+	#temporaryObjectIDs;
 	OPEN objectCursor FETCH NEXT
 FROM
 	objectCursor INTO @ObjectID,
-	@RenditionExists WHILE @ @FETCH_STATUS = 0 BEGIN EXEC IF @RenditionExists = 1 [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID;
-
-ELSE [dbo].[SP_BF_OnlineCollectionPayloadArchives] @ObjectID;
-
-FETCH NEXT
+	@RenditionExists WHILE @@FETCH_STATUS = 0 
+	BEGIN 
+	IF @RenditionExists = 1 EXEC [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID;
+	ELSE EXEC [dbo].[SP_BF_OnlineCollectionPayloadArchives] @ObjectID FETCH NEXT
 FROM
 	objectCursor INTO @ObjectID,
 	@RenditionExists
 END;
 
-CLOSE objectCursor DEALLOCATE objectCursor
-END
+CLOSE objectCursor DEALLOCATE objectCursor;

--- a/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
+++ b/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
@@ -66,7 +66,6 @@ FROM
 					ConAltNames cn
 					JOIN Constituents cts ON (
 						cn.ConstituentID = cts.ConstituentID
-						/*AND cts.Active = 1*/
 					)
 					JOIN ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId)
 			) const ON (
@@ -78,13 +77,6 @@ FROM
 		AND conxref1.RoleTypeID = 11
 		AND conxref1.RoleID = 11
 	)
-	/*Constituent */
-	/*INNER JOIN MediaRenditions mr1 ON mm.PrimaryRendID = mr1.RenditionID  
-	 INNER JOIN conxrefs cx1 on cx1.ID = o.objectid AND cx1.TableID = 108
-	 INNER JOIN Roles r1 on r1.RoleID = cx1.RoleID AND R1.RoleTypeID = 1 
-	 INNER JOIN ConXrefDetails cxd1 ON cx1.ConXrefID = cxd1.ConXrefID And CXD1.UnMasked = 1
-	 INNER JOIN ConAltNames cn1 ON cxd1.NameID = cn1.AltNameId
-	 INNER JOIN Constituents cts1 ON cn1.ConstituentID = cts1.ConstituentID 	*/
 	JOIN (
 		SELECT
 			cx1.ID,
@@ -107,8 +99,10 @@ FROM
 				cx1.ConXrefID = conx1.ConXrefID
 				AND conx1.UnMasked = 1
 			)
-	) constit1 on constit1.ID = o.objectid
-	AND constit1.TableID = 108;
+	) constit1 ON (
+		constit1.ID = O.ObjectID
+		AND constit1.TableID = 108
+	);
 
 DECLARE @ObjectID int;
 

--- a/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
+++ b/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
@@ -16,7 +16,7 @@ GO
 SET
 	NOCOUNT ON;
 
-CREATE TABLE #temporaryObjectIDs(TemporaryObjectID int, RenditionExists boolean)
+CREATE TABLE #temporaryObjectIDs(TemporaryObjectID int, RenditionExists BIT)
 /**
  The below query inserts objects from the `Objects` table into the temporary table `temporaryObjectIDs`
  Only objects that have media renditions are retrieved by the below query
@@ -146,7 +146,7 @@ WHERE
  */
 DECLARE @ObjectID int;
 
-DECLARE @RenditionExists boolean;
+DECLARE @RenditionExists BIT;
 
 DECLARE objectCursor CURSOR FOR
 SELECT

--- a/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
+++ b/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
@@ -1,94 +1,126 @@
+/****** Object:  StoredProcedure [dbo].[SP_BF_feed_onlinecollectionpayload]    Script Date: 12/19/2022 8:55:51 PM ******/
 USE [TMS]
 GO
-/****** Object:  StoredProcedure [dbo].[SP_BF_feed_onlinecollectionpayload]    Script Date: 12/19/2022 8:55:51 PM ******/
-SET ANSI_NULLS ON
+SET
+	ANSI_NULLS ON
 GO
-SET QUOTED_IDENTIFIER ON
+SET
+	QUOTED_IDENTIFIER ON
 GO
-
-
--- =============================================
--- Author:		<Author,,Name>
--- Create date: <Create Date,,>
--- Description:	<Description,,>
--- =============================================
-ALTER PROCEDURE [dbo].[SP_BF_feed_onlinecollectionpayload]
-	-- Add the parameters for the stored procedure here
-	
-AS
-BEGIN
-	-- SET NOCOUNT ON added to prevent extra result sets from
+	ALTER PROCEDURE [dbo].[SP_BF_feed_onlinecollectionpayload] -- Add the parameters for the stored procedure here
+	AS BEGIN -- SET NOCOUNT ON added to prevent extra result sets FROM
 	-- interfering with SELECT statements.
-	SET NOCOUNT ON;
-	create table #tempObjID(ObID int)
-    -- Insert statements for procedure here
-	insert into #tempObjID	SELECT distinct
-	O.ObjectID
-	from Objects O 
-	/* Classification */
+SET
+	NOCOUNT ON;
+
+CREATE TABLE #temporaryObjectIDs(TemporaryObjectID int)
+INSERT INTO
+	#temporaryObjectIDs	
+SELECT
+	DISTINCT O.ObjectID
+FROM
+	Objects O
+	/* Join the Classifications information */
 	INNER JOIN ClassificationXRefs CXR ON O.ObjectID = CXR.Id
-    INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId
-	/* Period, Culture */
+	INNER JOIN classifications Cs ON Cs.ClassificationID = CXR.ClassificationId
+	/* Join the tables containing Period AND Culture information */
 	INNER JOIN ObjContext Oc ON Oc.ObjectID = O.ObjectID
-	/* CopyrightStatus and CreditLineReproduction */
+	/* Join the tables containing CopyrightStatus AND CreditLineReproduction information */
 	INNER JOIN ObjRights Obr ON obr.OBJECTID = O.ObjectID
-	INNER JOIN ObjRightsTypes Ort on Ort.ObjRightsTypeID = Obr.ObjRightsTypeID
-	/*text Entries - short description, long description and published provenance */
-	LEFT OUTER JOIN TextEntries tes on tes.id = O.ObjectID and tes.Texttypeid = 48
-	LEFT OUTER JOIN TextEntries tel on tel.id = O.ObjectID and tel.Texttypeid = 49
-	LEFT OUTER JOIN TextEntries tep on tep.id = O.ObjectID and tep.Texttypeid = 55 
-	/* site, room, homelocation */
-	INNER JOIN objcomponents obc on o.objectID = obc.ObjectID 	 
-    INNER JOIN locations l on obc.HomeLocationID  = l.LocationID
-	INNER JOIN MediaXRefs mx On mx.ID = o.ObjectID And mx.TableID = 108 /*and Mx.PrimaryDisplay = 1*/
-	/* Photographer */	
-    INNER JOIN MediaMaster mm On mx.MediaMasterID = mm.MediaMasterID 
-INNER JOIN MediaRenditions mr ON (mm.MediaMasterID = mr.MediaMasterID and mm.PrimaryRendID = mr.RenditionID )
-left join MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
-join (select const.DisplayName,r.Role, cx.ID,cx.RoleTypeID,cx.RoleID  from ConXrefs cx join Roles r on (r.RoleID = cx.RoleID)
-                
-				join (select cts.DisplayName, cxd.ConXrefID, cxd.UnMasked  from ConAltNames cn
-                join Constituents cts on (cn.ConstituentID = cts.ConstituentID /*and cts.Active = 1*/)
-        join ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId))const
+	INNER JOIN ObjRightsTypes Ort ON Ort.ObjRightsTypeID = Obr.ObjRightsTypeID
+	/* Get the text entries columns. Short Description, Long Description AND Published Provenance */
+	LEFT OUTER JOIN TextEntries tes ON tes.id = O.ObjectID
+	AND tes.Texttypeid = 48
+	LEFT OUTER JOIN TextEntries tel ON tel.id = O.ObjectID
+	AND tel.Texttypeid = 49
+	LEFT OUTER JOIN TextEntries tep ON tep.id = O.ObjectID
+	AND tep.Texttypeid = 55
+	/* Get the information for the site, room, home location */
+	INNER JOIN objcomponents obc ON o.objectID = obc.ObjectID
+	INNER JOIN locations l ON obc.HomeLocationID = l.LocationID
+	INNER JOIN MediaXRefs mx ON mx.ID = o.ObjectID
+	AND mx.TableID = 108
+	/* Photographer */
+	INNER JOIN MediaMaster mm ON mx.MediaMasterID = mm.MediaMasterID
+	INNER JOIN MediaRenditions mr ON (
+		mm.MediaMasterID = mr.MediaMasterID
+		AND mm.PrimaryRendID = mr.RenditionID
+	)
+	LEFT JOIN MediaFiles mf ON (mr.PrimaryFileID = mf.FileID)
+	JOIN (
+		SELECT
+			const.DisplayName,
+			r.Role,
+			cx.ID,
+			cx.RoleTypeID,
+			cx.RoleID
+		FROM
+			ConXrefs cx
+			JOIN Roles r ON (r.RoleID = cx.RoleID)
+			JOIN (
+				SELECT
+					cts.DisplayName,
+					cxd.ConXrefID,
+					cxd.UnMasked
+				FROM
+					ConAltNames cn
+					JOIN Constituents cts ON (
+						cn.ConstituentID = cts.ConstituentID
+						/*AND cts.Active = 1*/
+					)
+					JOIN ConXrefDetails cxd ON (cxd.NameID = cn.AltNameId)
+			) const ON (
+				cx.ConXrefID = const.ConXrefID
+				AND const.UnMasked = 1
+			)
+	) conxref1 ON (
+		mr.RenditionID = conxref1.ID
+		AND conxref1.RoleTypeID = 11
+		AND conxref1.RoleID = 11
+	)
+	/*Constituent */
+	/*INNER JOIN MediaRenditions mr1 ON mm.PrimaryRendID = mr1.RenditionID  
+	 INNER JOIN conxrefs cx1 on cx1.ID = o.objectid AND cx1.TableID = 108
+	 INNER JOIN Roles r1 on r1.RoleID = cx1.RoleID AND R1.RoleTypeID = 1 
+	 INNER JOIN ConXrefDetails cxd1 ON cx1.ConXrefID = cxd1.ConXrefID And CXD1.UnMasked = 1
+	 INNER JOIN ConAltNames cn1 ON cxd1.NameID = cn1.AltNameId
+	 INNER JOIN Constituents cts1 ON cn1.ConstituentID = cts1.ConstituentID 	*/
+	JOIN (
+		SELECT
+			cx1.ID,
+			cx1.TableID
+		FROM
+			ConXrefs cx1
+			JOIN Roles r1 on (
+				r1.RoleID = cx1.RoleID
+				AND r1.RoleTypeID = 1
+			)
+			JOIN (
+				SELECT
+					cxd1.ConXrefID,
+					cxd1.UnMasked
+				FROM
+					ConAltNames cn1
+					JOIN Constituents cts1 on (cn1.ConstituentID = cts1.ConstituentID)
+					JOIN ConXrefDetails cxd1 ON (cxd1.NameID = cn1.AltNameId)
+			) conx1 ON (
+				cx1.ConXrefID = conx1.ConXrefID
+				AND conx1.UnMasked = 1
+			)
+	) constit1 on constit1.ID = o.objectid
+	AND constit1.TableID = 108;
 
-        ON (cx.ConXrefID = const.ConXrefID and const.UnMasked = 1))conxref1
-        ON (mr.RenditionID = conxref1.ID and conxref1.RoleTypeID = 11 and conxref1.RoleID = 11) 
-/*Constituent */
-/*INNER JOIN MediaRenditions mr1 ON mm.PrimaryRendID = mr1.RenditionID  
-INNER JOIN conxrefs cx1 on cx1.ID = o.objectid and cx1.TableID = 108
-INNER JOIN Roles r1 on r1.RoleID = cx1.RoleID and R1.RoleTypeID = 1 
-INNER JOIN ConXrefDetails cxd1 ON cx1.ConXrefID = cxd1.ConXrefID And CXD1.UnMasked = 1
-INNER JOIN ConAltNames cn1 ON cxd1.NameID = cn1.AltNameId
-INNER JOIN Constituents cts1 ON cn1.ConstituentID = cts1.ConstituentID 	*/	
+DECLARE @ObjectID int;
 
-join
-(select  cx1.ID, cx1.TableID  from ConXrefs cx1 
-               join Roles r1 on (r1.RoleID = cx1.RoleID and r1.RoleTypeID = 1)
-                join 
-				      (select  cxd1.ConXrefID, cxd1.UnMasked  from ConAltNames cn1
-                      join Constituents cts1 on (cn1.ConstituentID = cts1.ConstituentID)
-                     join ConXrefDetails cxd1 ON (cxd1.NameID = cn1.AltNameId))conx1
-
-                ON (cx1.ConXrefID = conx1.ConXrefID and conx1.UnMasked = 1))constit1
-on constit1.ID = o.objectid and constit1.TableID = 108
-
-DECLARE	@ObjectID int
-
-DECLARE cur CURSOR FOR SELECT ObID FROM #tempObjID
-OPEN cur
-
-FETCH NEXT FROM cur INTO @ObjectID
-
-WHILE @@FETCH_STATUS = 0 BEGIN
-    EXEC [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID 
-    FETCH NEXT FROM cur INTO @ObjectID
+DECLARE objectCursor CURSOR FOR
+SELECT
+	TemporaryObjectID
+FROM
+	#temporaryObjectIDs
+	OPEN objectCursor FETCH NEXT
+FROM
+	objectCursor INTO @ObjectID WHILE @ @FETCH_STATUS = 0 BEGIN EXEC [dbo].[SP_BF_OnlineCollectionPayload] @ObjectID FETCH NEXT
+FROM
+	objectCursor INTO @ObjectID
+END CLOSE objectCursor DEALLOCATE objectCursor
 END
-
-CLOSE cur    
-DEALLOCATE cur
-
-
-END
-
-
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compileOnSave": true,
 	"compilerOptions": {
+		"sourceMap": true,
 		"lib": ["dom", "es2018"],
 		"target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
 		"module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compileOnSave": true,
 	"compilerOptions": {
+		"lib": ["dom", "es2018"],
 		"target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
 		"module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
 		"outDir": "dist", /* Redirect output structure to the directory. */


### PR DESCRIPTION
This pull request adds support for pulling `archive` records from TMS. They differ from the records currently pulled in the sync because they do not typically have an associated Media record in TMS. Subsequently, they will not having corresponding media record data, such as those we store in the `media_information` table. We also differentiate between `archive` and `media` records in the database with the introduction of the `objectType` column in the `main_object_information` table.

This pull request does the following to support archives syncing
- Handles errors during parsing the JSON information [in the TextEntry value](https://github.com/BarnesFoundation/dams-sync/pull/14/files#diff-e2829ae4701ed1a270f1f302a005a36a00283d2f402f6c5b671b2e5f18c7fe9aR50-R79)
- [Handles the case of constituent record data parsing for archive records](https://github.com/BarnesFoundation/dams-sync/pull/14/files#diff-e2829ae4701ed1a270f1f302a005a36a00283d2f402f6c5b671b2e5f18c7fe9aR106-R142), which have no associated constituent record data
- [Adds the objectType and description fields](https://github.com/BarnesFoundation/dams-sync/pull/14/files#diff-1b8788d5da7bc5daed0e18501bf45162f6b6f3da63e3a8132386b1b656583549R42-R44), needed since we're syncing over archives
- Creates the virtual `renditionNumber` [field value for archive-type records](https://github.com/BarnesFoundation/dams-sync/pull/14/files#diff-fb56f85098e281863e1d5b4d1dd32b788af840867c83bca8e1a1214c22ca0f3cR41-R77)

This code is now deployed in the NetX Intermediate Database sync and is pulling both archives and regular media records.