### PR TITLE
fix-some-archives-not-being-pulled

### DIFF
--- a/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
+++ b/storedProcedures/SP_BF_feed_onlinecollectionpayload.sql
@@ -133,12 +133,15 @@ WHERE
 	-- This is the DepartmentID that indicates "Archives"
 	O.DepartmentID = '23'
 	/* This below filter query retrieves those Archives that do not have media renditions. */
+	/** Commenting this out as this appears to be filtering out archives that should be included */
+	/*
 	AND O.ObjectID NOT IN (
 		SELECT
 			MediaXrefs.ID
 		FROM
 			MediaXrefs
 	);
+	*/
 
 /**
  * Runs the stored procedure `SP_BF_OnlineCollectionPayload` for each TemporaryObjectID in our `temporaryObjectIDs` table


### PR DESCRIPTION
This pull request comments out [a filter query I had added](https://github.com/BarnesFoundation/dams-sync/compare/fix-some-archives-not-being-pulled?expand=1#diff-e72377fcb49dee5c78ca6da7862cb65cf2d140ca28c8fd66a2b5776cbabab1cdR136-R144) when we were adding code for fetching archives.

This filter query was causing the following archive records to be filtered out from the stored procedure process

```
AR.ABC.1913.100
AR.ABC.1913.102
AR.ABC.1913.103
AR.ABC.1913.104
AR.ABC.1913.105
AR.ABC.1913.106
AR.ABC.1913.107
AR.ABC.1913.108
AR.ABC.1913.109
```

This modification needs to be deployed to the stored procedure `SP_BF_feed_onlinecollectionpayload.sql` in the TMS database.