### PR TITLE
add-last-modified-columns

### DIFF
--- a/netxQueries.ts
+++ b/netxQueries.ts
@@ -25,3 +25,47 @@ CROSS JOIN (
 ) "constituentInfo"
 WHERE "renditionNumber" = '01-27-02_i1r'
 `;
+
+// For retrieving all archive records modified in the past 24-hours
+const archivesInLastHours = 
+`
+SELECT mi."objectId"
+	,mi."renditionNumber"
+	,tes."lastUpdatedAt"
+FROM media_information mi
+INNER JOIN text_entry_store tes ON tes."objectId" = mi."objectId"
+WHERE mi."objectId" IN (
+		SELECT "objectId"
+		FROM main_object_information moi
+		WHERE moi."objectType" = 'archive'
+			AND moi."objectId" IN (
+				SELECT "objectId"
+				FROM text_entry_store tes
+				WHERE tes."lastUpdatedAt" BETWEEN NOW() - INTERVAL '24 HOURS'
+						AND NOW()
+				)
+		)
+ORDER BY tes."lastUpdatedAt" DESC
+`;
+
+// For retrieving all archive records modified in the past 24-hours
+const mediaInLastHours = 
+`
+SELECT mi."objectId"
+	,mi."renditionNumber"
+	,tes."lastUpdatedAt"
+FROM media_information mi
+INNER JOIN text_entry_store tes ON tes."objectId" = mi."objectId"
+WHERE mi."objectId" IN (
+		SELECT "objectId"
+		FROM main_object_information moi
+		WHERE moi."objectType" = 'media'
+			AND moi."objectId" IN (
+				SELECT "objectId"
+				FROM text_entry_store tes
+				WHERE tes."lastUpdatedAt" BETWEEN NOW() - INTERVAL '24 HOURS'
+						AND NOW()
+				)
+		)
+ORDER BY tes."lastUpdatedAt" DESC
+`;

--- a/scripts/createUsers.sql
+++ b/scripts/createUsers.sql
@@ -4,3 +4,4 @@ GRANT REFERENCES, SELECT ON TABLE public.constituent_records TO netx_dams;
 GRANT REFERENCES, SELECT ON TABLE public.main_object_information TO netx_dams;
 GRANT REFERENCES, SELECT ON TABLE public.media_information TO netx_dams;
 GRANT REFERENCES, SELECT ON TABLE public.object_constituent_mappings TO netx_dams;
+GRANT REFERENCES, SELECT ON TABLE public.text_entry_store TO netx_dams;

--- a/src/classes/databaseInitializer.ts
+++ b/src/classes/databaseInitializer.ts
@@ -35,7 +35,7 @@ export class DatabaseInitializer {
 		const { constituentRecords } = NetXTables;
 		const primaryColumn = constituentRecords.columns[0];
 
-		const columnsString = constituentRecords.columns.map((column, index, array) => `"${column.name}" ${column.type}`)
+		const columnsString = constituentRecords.columns.map((column) => `"${column.name}" ${column.type}`)
 			.join(',\n');
 
 		// Query to create table
@@ -48,6 +48,26 @@ export class DatabaseInitializer {
 
 		await this.netxCon.executeQuery(query);
 	};
+
+		/** Creates the text entry values table -- generates the raw sql to do so and executes it */
+		public createTextEntryStoreTable = async () => {
+
+			const { textEntryStore } = NetXTables;
+			const primaryColumn = textEntryStore.columns[0];
+	
+			const columnsString = textEntryStore.columns.map((column) => `"${column.name}" ${column.type}`)
+				.join(',\n');
+	
+			// Query to create table
+			const query = `
+			CREATE TABLE IF NOT EXISTS ${textEntryStore.tableName} (
+				${columnsString},
+				PRIMARY KEY ("${primaryColumn.name}")
+			);
+			`;
+	
+			await this.netxCon.executeQuery(query);
+		};
 
 	/** Creates the object-to-constituent mapping table. Sets up the needed foreign/primary key relationships 
 	 * between it and the constituent record/main object information tables,

--- a/src/classes/mainSyncProcess.ts
+++ b/src/classes/mainSyncProcess.ts
@@ -23,7 +23,9 @@ export class MainSyncProcess {
 			FROM TextEntries 
 			WHERE TextTypeId = 67
 			AND TextEntry IS NOT NULL
-			AND TextEntry != ''`;
+			AND TextEntry != ''
+			ORDER BY ID ASC
+			`;
 
 		// From knowledge of the database - we have around 7622 objects we will work with - get the exact count to make sure
 		const recordset = (await this.tmsCon.executeQuery(objectIdQuery)).recordset as ObjectID[];
@@ -63,6 +65,7 @@ export class MainSyncProcess {
 		const parallelExecutionLimit = 75;
 		const numberOfBatches = Math.ceil(count / parallelExecutionLimit);
 
+		console.log(`There are ${count} records to process from TMS`);
 		console.log(`There will be ${numberOfBatches} batches of ${parallelExecutionLimit} executions each`);
 
 		// Retrieve the objects in batches

--- a/src/classes/mainSyncProcess.ts
+++ b/src/classes/mainSyncProcess.ts
@@ -40,6 +40,9 @@ export class MainSyncProcess {
 		// Create the NetX main object table
 		await db.createMainObjectTable();
 
+		// Create the NetX text entry storage table
+		await db.createTextEntryStoreTable();
+
 		// Create the NetX constituent records table
 		await db.createConstituentTable();
 

--- a/src/classes/objectProcess.ts
+++ b/src/classes/objectProcess.ts
@@ -61,6 +61,7 @@ export class ObjectProcess {
 
 			if (Boolean(textEntryValue) === false) {
 				console.warn(`No "TextEntry" data available for Object ID "${this.objectId}"`, textEntryValue);
+				this.netxClient.release();
 				return resolve('');
 			}
 			const cpTextEntry = textEntryValue.replace(NEWLINE_RETURN_TAB_REGEX, '');
@@ -74,6 +75,7 @@ export class ObjectProcess {
 			// then there's been no new data for the record. We can move forward without
 			// doing any subsequent processing because the data is the same
 			if (storedTextEntry === cpTextEntry) {
+				this.netxClient.release();
 				return resolve('')
 			}
 

--- a/src/classes/objectProcess.ts
+++ b/src/classes/objectProcess.ts
@@ -66,7 +66,7 @@ export class ObjectProcess {
 			const cpTextEntry = textEntryValue.replace(NEWLINE_RETURN_TAB_REGEX, '');
 
 			// Execute the query to get the stored text entry we have in the NetX intermediate database
-			const storedTextEntryQueryResult = await this.netxCon.executeQuery(storedTextEntryQuery);
+			const storedTextEntryQueryResult = await this.netxClient.query(storedTextEntryQuery);
 			const storedTextEntryRecordSet = storedTextEntryQueryResult?.rows;
 			const storedTextEntry = storedTextEntryRecordSet?.length ? storedTextEntryRecordSet[0].textEntry : ''
 
@@ -83,7 +83,7 @@ export class ObjectProcess {
 			const { query: textEntryInsertQuery, values: textEntryInsertValues } = QueryHelpers.insertQueryGenerator(NetXTables.textEntryStore, {
 				objectId: this.objectId, textEntry: cpTextEntry, lastUpdatedAt: new Date()
 			})
-			await this.netxCon.executeQuery(textEntryInsertQuery, textEntryInsertValues);
+			await this.netxClient.query(textEntryInsertQuery, textEntryInsertValues);
 
 			try {
 				const parsedCollectionPayload = JSON.parse(cpTextEntry) as CollectionPayload;

--- a/src/constants/netXDatabase.ts
+++ b/src/constants/netXDatabase.ts
@@ -97,6 +97,15 @@ export const NetXTables: TablesInformation = {
 			{ name: 'mediaView', type: 'VARCHAR' },
 			{ name: 'publicAccess', type: 'INTEGER' }
 		]
+	},
+
+	textEntryStore: {
+		tableName: 'text_entry_store',
+		columns: [
+			{ name: 'objectId', type: 'INTEGER', primary: true },
+			{ name: 'textEntry', type: 'VARCHAR' },
+			{ name: 'lastUpdatedAt', type: 'TIMESTAMP' }
+		]
 	}
 };
 

--- a/src/interfaces/netXDatabaseInterfaces.ts
+++ b/src/interfaces/netXDatabaseInterfaces.ts
@@ -2,7 +2,8 @@ export interface TablesInformation {
 	mainObjectInformation: TableInformation,
 	constituentRecords: TableInformation,
 	objectConstituentMappings: TableInformation,
-	mediaInformation: TableInformation
+	mediaInformation: TableInformation,
+	textEntryStore: TableInformation
 }
 
 export interface TableInformation {
@@ -15,7 +16,7 @@ export interface TableInformation {
 
 interface ColumnInformation {
 	name: string,
-	type: 'VARCHAR' | 'INTEGER' | 'SERIAL',
+	type: 'VARCHAR' | 'INTEGER' | 'SERIAL' | 'TIMESTAMP',
 	primary?: true,
 	foreign?: true
 }


### PR DESCRIPTION
This pull request adds the code to do the following
- During the processing of any Object ID that we've gathered from TMS, we'll stored the raw TextEntry value for it on our end and note the date we stored it
- We compare the current information for the record from TMS and what we have stored. If they are the same, we stop processing for that object information since there's no new changes and so no further processing is needed
- If the records are different, then the object in TMS has changed from what we've stored, and we need to update our stored value for it. We then allow processing to continue and update our NetX related tables

I've added the 2 queries we provided to Paul that will allow NetX to query for all archives/media records that were updated in the last X hours.

This completes introduction of the Date column into our NetX Intermediate Database so that the Periodic Sync does not process every single record during each run.