### PR TITLE
DAMS-2-modify-population-of-the-text-entry-store-table

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ class Application {
 
 	/** Performs the run of this application */
 	public async perform() {
+		const start = Date.now();
 		Logger.debug(`Beginning sync`);
 
 		// Set up our connections to TMS and NetX
@@ -27,7 +28,10 @@ class Application {
 		// Now that we're done, close connections
 		await this.closeDatabaseConnections();
 
-		Logger.debug(`Ending sync`);
+		const elapsedTime = Date.now() - start;
+		const minutes = Math.floor(elapsedTime / 60000);
+		const seconds = parseInt(((elapsedTime % 60000) / 1000).toFixed(0));
+		Logger.debug(`Ending sync after ${minutes} minutes and ${(seconds < 10 ? '0' : '')}${seconds} seconds`);
 	}
 
 	/** Initializes each of our connections - 1 to TMS and 1 to NetX */

--- a/src/classes/mainSyncProcess.ts
+++ b/src/classes/mainSyncProcess.ts
@@ -32,10 +32,10 @@ export class MainSyncProcess {
 			`;
 
 		// From knowledge of the database - we have around 7622 objects we will work with - get the exact count to make sure
-		const recordset = (await this.tmsCon.executeQuery(objectIdQuery)).recordset as ObjectID[];
-		const count = recordset.length;
+		const queryResult = await this.tmsCon.executeQuery(objectIdQuery);
+		const recordset = queryResult.recordset as ObjectID[]
 
-		return { recordset, count };
+		return { recordset, count:  recordset.length };
 	};
 
 	/** Initializes the NetX database as this should only run once during each sync*/
@@ -149,6 +149,10 @@ export class MainSyncProcess {
 		const parallelCreationLimit = 2;
 		const splitModifiedRecordSet = splitArray(modifiedRecordIdSet, 1000)
 		const numberOfCreationBatches = Math.ceil(splitModifiedRecordSet.length / parallelCreationLimit);
+
+		Logger.debug(`There are ${modifiedRecordIdSet.length} records to create or update into NetX`);
+		Logger.debug(`There will be total ${numberOfCreationBatches} batches of ${parallelCreationLimit} executions.
+					  Each execution contains 1000 records`);
 
 		for (let j = 0; j <= numberOfCreationBatches; j++) {
 

--- a/src/classes/objectProcess.ts
+++ b/src/classes/objectProcess.ts
@@ -18,100 +18,56 @@ const {
 
 export class ObjectProcess {
 
-	private objectId: number;
-	private tmsCon: SQLConnection;
+	private objects: Array<CollectionPayloadTextEntry>;
 	private netxCon: SQLConnection;
 	private netxClient: PoolClient;
-	private processNumber: number;
-	private batchNumber: number;
 
-	constructor(objectId: ObjectID, tmsCon: SQLConnection, netxCon: SQLConnection, processNumber: number, batchNumber: number) {
-		this.objectId = objectId.ID;
-		this.tmsCon = tmsCon;
+	constructor(objects: Array<CollectionPayloadTextEntry>, netxCon: SQLConnection) {
 		this.netxCon = netxCon;
-		this.processNumber = processNumber;
-		this.batchNumber = batchNumber;
+		this.objects = objects.filter((object) => Boolean(object.TextEntry)).map((object) => ({
+			...object,
+			TextEntry: object.TextEntry?.replace(NEWLINE_RETURN_TAB_REGEX, ''),
+		}));
 	}
 
 	/** Handles performing the main process to parsing and adding an object to the NetX database */
 	public async perform() {
 		return new Promise(async (resolve) => {
-
-			// Since we're going to perform SQL transactions on NetX - checkout a client
 			this.netxClient = await this.netxCon.checkoutClient();
 
-			// Query to get the Online Collection Payload for this object id
-			const collectionPayloadQuery = `
-			SELECT TextEntry 
-			FROM TextEntries 
-			WHERE ID = ${this.objectId} 
-			AND TextTypeId = 67
-			AND TextEntry IS NOT NULL`;
+			const currentDate = new Date();
+			const formattedObjects = this.objects.map((object) => ({
+				objectId: object.ID, textEntry: object.TextEntry, lastUpdatedAt: currentDate
+			}))
 
-			// Check if this copy differs from the last processed version of data we have
-			const storedTextEntryQuery = `
-			SELECT "textEntry"
-			FROM "text_entry_store"
-			WHERE "objectId" = ${this.objectId}
-			`;
+			const textEntryQueryAndValues = QueryHelpers.insertQueryGenerator(NetXTables.textEntryStore, formattedObjects)
+			await this.netxClient.query(textEntryQueryAndValues.query, textEntryQueryAndValues.values);
 
-			// Execute the query to get the text entry from TMS 
-			const queryResult = await this.tmsCon.executeQuery(collectionPayloadQuery);
-			const recordSet = queryResult.recordset as CollectionPayloadTextEntry[];
-			const textEntryValue = recordSet[0]?.TextEntry;
+			for (let j = 0; j < formattedObjects.length; j++) {
+				const formattedObject = formattedObjects[j]
 
-			if (Boolean(textEntryValue) === false) {
-				Logger.warn(`No "TextEntry" data available for Object ID "${this.objectId}"`, textEntryValue);
-				this.netxClient.release();
-				return resolve('');
-			}
-			const cpTextEntry = textEntryValue.replace(NEWLINE_RETURN_TAB_REGEX, '');
+				try {
+					const parsedCollectionPayload = JSON.parse(formattedObject.textEntry) as CollectionPayload;
+					for (let i = 0; i < parsedCollectionPayload[OBJECT_RECORD].length; i++) {
 
-			// Execute the query to get the stored text entry we have in the NetX intermediate database
-			const storedTextEntryQueryResult = await this.netxClient.query(storedTextEntryQuery);
-			const storedTextEntryRecordSet = storedTextEntryQueryResult?.rows;
-			const storedTextEntry = storedTextEntryRecordSet?.length ? storedTextEntryRecordSet[0].textEntry : ''
-
-			// If our stored version of the text entry matches the current one from TMS
-			// then there's been no new data for the record. We can move forward without
-			// doing any subsequent processing because the data is the same
-			if (storedTextEntry === cpTextEntry) {
-				this.netxClient.release();
-				return resolve('')
-			}
-
-			// At this point, the version of the TextEntry we have stored differs from
-			// what currently exists in TMS. Let's persist this new value into the TextEntryStore
-			Logger.info(`Stored version of TextEntry for Object ID ${this.objectId} is being updated`)
-			const { query: textEntryInsertQuery, values: textEntryInsertValues } = QueryHelpers.insertQueryGenerator(NetXTables.textEntryStore, {
-				objectId: this.objectId, textEntry: cpTextEntry, lastUpdatedAt: new Date()
-			})
-			await this.netxClient.query(textEntryInsertQuery, textEntryInsertValues);
-
-			try {
-				const parsedCollectionPayload = JSON.parse(cpTextEntry) as CollectionPayload;
-				for (let i = 0; i < parsedCollectionPayload[OBJECT_RECORD].length; i++) {
-
-					// Add the parsed record to the NetX intermediate database
-					const objectRecord = parsedCollectionPayload[OBJECT_RECORD][i];
-					await this.addObjectRecordToNetX(objectRecord);
+						// Add the parsed record to the NetX intermediate database
+						const objectRecord = parsedCollectionPayload[OBJECT_RECORD][i];
+						await this.addObjectRecordToNetX(objectRecord);
+					}
 				}
-			}
 
-			catch (error) {
-				if (error instanceof SyntaxError) {
-					Logger.error(`Encountered an error parsing JSON. Object ID was "${this.objectId}"`);
-				} else {
-					Logger.error(`Encountered error during addition of object record to NetX Intermediat Database. Object ID was "${this.objectId}"`, error);
+				catch (error) {
+					if (error instanceof SyntaxError) {
+						Logger.error(`Encountered an error parsing the TextEntry JSON. Object ID was "${formattedObject.objectId}"`);
+					} else {
+						Logger.error(`Encountered error during addition of object record to NetX Intermediat Database. Object ID was "${formattedObject.objectId}"`, error);
+					}
 				}
 			}
 
 			// Now that we've finished everything - release the client
 			this.netxClient.release();
 			resolve('');
-
-			// Inform that the batch this process belongs to has completed
-			Logger.debug(`Completed Batch Number ${this.batchNumber} Process Number ${this.processNumber}`);
 		});
 	}
 
@@ -128,7 +84,7 @@ export class ObjectProcess {
 		const {
 			query: moQuery,
 			values: moValues
-		} = QueryHelpers.insertQueryGenerator(tableMainObjectInformation, mainInformationObject);
+		} = QueryHelpers.insertQueryGenerator(tableMainObjectInformation, [mainInformationObject]);
 		await this.netxClient.query(moQuery, moValues);
 
 		// Add each constituent record in the list. The constituent record list will not exist
@@ -138,17 +94,17 @@ export class ObjectProcess {
 				const cr = constituentRecordsList[i];
 
 				// Add the constituent record row
-				const { query: crQuery, values: crValues } = QueryHelpers.insertQueryGenerator(tableConstituentRecords, cr);
+				const { query: crQuery, values: crValues } = QueryHelpers.insertQueryGenerator(tableConstituentRecords, [cr]);
 				await this.netxClient.query(crQuery, crValues);
 
 				// Add the mapping between the main object and its constituents
 				const {
 					query: mapQuery,
 					values: mapValues
-				} = QueryHelpers.insertQueryGenerator(tableObjectConstituentMappings, {
+				} = QueryHelpers.insertQueryGenerator(tableObjectConstituentMappings, [{
 					constituentRecordId: cr.constituentID,
 					objectId: or.objectId,
-				});
+				}]);
 
 				try { await this.netxClient.query(mapQuery, mapValues); }
 				catch (error) {
@@ -166,7 +122,7 @@ export class ObjectProcess {
 			const {
 				query: miQuery,
 				values: miValues,
-			} = QueryHelpers.insertQueryGenerator(tableMediaInformation, mediaInformationObject);
+			} = QueryHelpers.insertQueryGenerator(tableMediaInformation, [mediaInformationObject]);
 			await this.netxClient.query(miQuery, miValues);
 		}
 	}

--- a/src/constants/arrayHelpers.ts
+++ b/src/constants/arrayHelpers.ts
@@ -1,0 +1,14 @@
+export function splitArray<T>(array: Array<T>, splitSize: number): Array<Array<T>> {
+    const result = [];
+    for (let i = 0; i < array.length; i += splitSize) {
+        const chunk = array.slice(i, i + splitSize);
+        result.push(chunk);
+    }
+    return result;
+}
+
+export function flattenArray<T>(list: Array<Array<T>>): Array<T> {
+    return list.reduce((acc, curVal) => {
+        return acc.concat(curVal)
+    }, []);
+}

--- a/src/constants/queryHelpers.ts
+++ b/src/constants/queryHelpers.ts
@@ -2,43 +2,40 @@ import { TableInformation } from '../interfaces/netXDatabaseInterfaces';
 import { Logger } from '../logger';
 
 /** Generates the query for inserting a record along with the values to be inserted */
-const insertQueryGenerator = (table: TableInformation, object: { [key: string]: any }) => {
-
-	const { tableName } = table;
-	const columnNamesToInsert = [];
-	const values = [];
-
-	if (!object) {
-		Logger.debug(tableName, object);
+const insertQueryGenerator = (table: TableInformation, objects: Array<{ [key: string]: any }>) => {
+	if (!objects || objects.length == 0) {
+		Logger.debug(`No objects provided for insertion to table "${table.tableName}"`, objects.join());
 	}
 
-	for (let [fieldName, fieldValue] of Object.entries(object)) {
-		columnNamesToInsert.push(`"${fieldName}"`);
-		values.push(fieldValue);
-	}
+	const usableObject = objects[0];
+	const columnNamesToInsert = Object.keys(usableObject).map((fieldName) => {
+		return `"${fieldName}"`;
+	});
+	const valuesToInsert = flatten(objects.map((object) => {
+		return Object.values(object).map((fieldValue) => fieldValue)
+	}));
 
 	// Once we've gone through all the field names - we can build our insert query
 	const columnString = columnNamesToInsert.join();
-	const valuesPlaceholder = values.map((_, index) => `$${index + 1}`).join();
-
+	const valuesPlaceholder = expand(objects.length, columnNamesToInsert.length)
 	const onConflictCommand = generateOnConflictCommand(table, columnNamesToInsert);
 
 	// Build our query for this row
 	const query = `
-	INSERT INTO ${tableName} (${columnString})
-	VALUES (${valuesPlaceholder})
+	INSERT INTO ${table.tableName} (${columnString})
+	VALUES ${valuesPlaceholder}
 	${onConflictCommand}
 	`;
 
-	return { query, values };
+	return { query, values: valuesToInsert };
 };
 
-/** Generates the ON CONFLICT cluase of the insert query. This is crucial for records that already exist in the database to be updated with
- * new information during future runs.
+/** Generates the ON CONFLICT cluase of the insert query. This is crucial for records that 
+ * already exist in the database to be updated with new information during subsequent runs.
  */
 const generateOnConflictCommand = (table: TableInformation, columnNamesToInsert: string[]): string => {
 
-	// Get the primary key columns as these are how we'l know a conflict occurs
+	// Get the primary key columns as these are how we'll know a conflict occurs
 	const primaryColumns = table.columns.filter((column) => column.primary == true).map((column) => `"${column.name}"`);
 	const constraintString = `(${primaryColumns.join()})`;
 
@@ -71,5 +68,17 @@ const generateOnConflictCommand = (table: TableInformation, columnNamesToInsert:
 const QueryHelpers = {
 	insertQueryGenerator
 };
+
+function expand(rowCount: number, columnCount: number, startAt = 1) {
+	let index = startAt;
+	return Array(rowCount).fill(0).map(v => `(${Array(columnCount).fill(0).map(v => `$${index++}`).join(", ")})`).join(", ")
+}
+
+function flatten<T>(arrayToFlatten: T[][]) {
+	const flattenedArray: T[] = []
+
+	arrayToFlatten.forEach(v => v.forEach((p: any) => flattenedArray.push(p)))
+	return flattenedArray
+}
 
 export default QueryHelpers;

--- a/src/interfaces/queryResponses.ts
+++ b/src/interfaces/queryResponses.ts
@@ -3,7 +3,8 @@ export interface ObjectID {
 };
 
 export interface CollectionPayloadTextEntry {
-	TextEntry: string
+	ID: number,
+	TextEntry?: string,
 };
 
 export interface CollectionPayload {
@@ -14,4 +15,9 @@ export type ObjectRecord = NormalObject & { ConstituentRecord?: NormalObject[] }
 
 export interface NormalObject {
 	[key: string]: string | number,
+}
+
+export interface StoredTextEntry {
+	objectId: number,
+	textEntry: string,
 }


### PR DESCRIPTION
https://barnesfoundation.atlassian.net/browse/DAMS-2

This pull request modifies how and when we're querying TMS' TextEntry table. Rather than spawning 1000's of Node processes to query TMS for a single ObjectId and then checking if it was changed in TMS compared to our stored version individually, we query for 1000 records upfront in a series of Node processes and collect any modified records into a single list.

That way, we know up front which records had changes and can log them easily to see in the log files. Then we kick off Node process - which are much less in number - to process those changed records and update the database.

This is much more optimized for scale and runs faster than our current implementation.